### PR TITLE
Refactor/properties

### DIFF
--- a/src/main/java/org/elasql/migration/albatross/BgPushProcedure.java
+++ b/src/main/java/org/elasql/migration/albatross/BgPushProcedure.java
@@ -39,7 +39,7 @@ public class BgPushProcedure extends CalvinStoredProcedure<BgPushParamHelper> {
 		ExecutionPlan plan;
 		
 		// Sequencer skips
-		if (Elasql.isSequencer())
+		if (Elasql.isStandAloneSequencer())
 			return new ExecutionPlan();
 		
 		// prepare parameters

--- a/src/main/java/org/elasql/migration/mgcrab/OnePhaseBgPushProcedure.java
+++ b/src/main/java/org/elasql/migration/mgcrab/OnePhaseBgPushProcedure.java
@@ -39,7 +39,7 @@ public class OnePhaseBgPushProcedure extends CalvinStoredProcedure<OnePhaseBgPus
 		ExecutionPlan plan;
 		
 		// Sequencer skips
-		if (Elasql.isSequencer())
+		if (Elasql.isStandAloneSequencer())
 			return new ExecutionPlan();
 		
 		// prepare parameters

--- a/src/main/java/org/elasql/migration/mgcrab/TwoPhaseBgPushProcedure.java
+++ b/src/main/java/org/elasql/migration/mgcrab/TwoPhaseBgPushProcedure.java
@@ -43,7 +43,7 @@ public class TwoPhaseBgPushProcedure extends CalvinStoredProcedure<TwoPhaseBgPus
 		ExecutionPlan plan;
 		
 		// Sequencer skips
-		if (Elasql.isSequencer())
+		if (Elasql.isStandAloneSequencer())
 			return new ExecutionPlan();
 		
 		// prepare parameters

--- a/src/main/java/org/elasql/migration/squall/BgPushProcedure.java
+++ b/src/main/java/org/elasql/migration/squall/BgPushProcedure.java
@@ -39,7 +39,7 @@ public class BgPushProcedure extends CalvinStoredProcedure<BgPushParamHelper> {
 		ExecutionPlan plan;
 		
 		// Sequencer skips
-		if (Elasql.isSequencer())
+		if (Elasql.isStandAloneSequencer())
 			return new ExecutionPlan();
 		
 		// prepare parameters

--- a/src/main/java/org/elasql/procedure/calvin/CalvinStoredProcedure.java
+++ b/src/main/java/org/elasql/procedure/calvin/CalvinStoredProcedure.java
@@ -91,7 +91,7 @@ public abstract class CalvinStoredProcedure<H extends StoredProcedureParamHelper
 //		timer.stopComponentTimer(getClass().getSimpleName() + " analyze paramters");
 		
 		// The sequencer only analyzes the parameters
-		if (Elasql.isSequencer()) {
+		if (Elasql.isStandAloneSequencer()) {
 			return;
 		}
 		
@@ -130,7 +130,7 @@ public abstract class CalvinStoredProcedure<H extends StoredProcedureParamHelper
 
 		// analyze read-write set
 		ReadWriteSetAnalyzer analyzer;
-		if (Elasql.isSequencer()) {
+		if (Elasql.isStandAloneSequencer()) {
 			// The sequencer monitors transactions
 			SequencerAnalyzer seqAnalyzer = new SequencerAnalyzer();
 			prepareKeys(seqAnalyzer);

--- a/src/main/java/org/elasql/remote/groupcomm/client/BatchSpcSender.java
+++ b/src/main/java/org/elasql/remote/groupcomm/client/BatchSpcSender.java
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.elasql.remote.groupcomm.StoredProcedureCall;
+import org.elasql.remote.groupcomm.server.ConnectionMgr;
 import org.elasql.util.ElasqlProperties;
 import org.vanilladb.comm.client.VanillaCommClient;
 import org.vanilladb.comm.view.ProcessType;
@@ -45,13 +46,12 @@ class BatchSpcSender implements Runnable {
 	private Queue<StoredProcedureCall> spcQueue = new ConcurrentLinkedQueue<StoredProcedureCall>();
 	private VanillaCommClient commClient;
 	private long lastSendingTime;
-	private int nodeId, sequencerId;
+	private int nodeId;
 
 	public BatchSpcSender(int id, VanillaCommClient client) {
 		commClient = client;
 		lastSendingTime = System.currentTimeMillis();
 		nodeId = id;
-		sequencerId = client.getServerCount() - 1;
 	}
 
 	@Override
@@ -103,6 +103,6 @@ class BatchSpcSender implements Runnable {
 			batchSpc.add(spc);
 		}
 		numOfQueuedSpcs.addAndGet(-batchSpc.size());
-		commClient.sendP2pMessage(ProcessType.SERVER, sequencerId, batchSpc.toArray(new StoredProcedureCall[0]));
+		commClient.sendP2pMessage(ProcessType.SERVER, ConnectionMgr.SEQUENCER_ID, batchSpc.toArray(new StoredProcedureCall[0]));
 	}
 }

--- a/src/main/java/org/elasql/remote/groupcomm/client/BatchSpcSender.java
+++ b/src/main/java/org/elasql/remote/groupcomm/client/BatchSpcSender.java
@@ -32,11 +32,11 @@ import org.vanilladb.comm.view.ProcessType;
 class BatchSpcSender implements Runnable {
 	private static Logger logger = Logger.getLogger(BatchSpcSender.class.getName());
 
-	private final static int BATCH_SIZE;
+	private final static int COMM_BATCH_SIZE;
 	private final static long MAX_WAITING_TIME; // in ms
 
 	static {
-		BATCH_SIZE = ElasqlProperties.getLoader()
+		COMM_BATCH_SIZE = ElasqlProperties.getLoader()
 				.getPropertyAsInteger(BatchSpcSender.class.getName() + ".BATCH_SIZE", 1);
 		MAX_WAITING_TIME = ElasqlProperties.getLoader()
 				.getPropertyAsInteger(BatchSpcSender.class.getName() + ".MAX_WAITING_TIME", 1000);
@@ -58,7 +58,7 @@ class BatchSpcSender implements Runnable {
 	public void run() {
 		// periodically send batch of requests
 		if (logger.isLoggable(Level.INFO))
-			logger.info("start batching-request worker thread (batch size = " + BATCH_SIZE + ")"); 
+			logger.info("start batching-request worker thread (batch size = " + COMM_BATCH_SIZE + ")"); 
 
 		while (true)
 			sendBatchRequestToDb();
@@ -69,7 +69,7 @@ class BatchSpcSender implements Runnable {
 		spcQueue.add(spc);
 		int size = numOfQueuedSpcs.incrementAndGet();
 		
-		if (size >= BATCH_SIZE) {
+		if (size >= COMM_BATCH_SIZE) {
 			synchronized (this) {
 				notifyAll();
 			}
@@ -81,7 +81,7 @@ class BatchSpcSender implements Runnable {
 		int size = numOfQueuedSpcs.get();
 		long currentTime = System.currentTimeMillis();
 		try {
-			while (size < BATCH_SIZE && (currentTime - lastSendingTime < MAX_WAITING_TIME || size < 1)) {
+			while (size < COMM_BATCH_SIZE && (currentTime - lastSendingTime < MAX_WAITING_TIME || size < 1)) {
 				
 				synchronized (this) {
 					wait(100);

--- a/src/main/java/org/elasql/remote/groupcomm/client/GroupCommConnection.java
+++ b/src/main/java/org/elasql/remote/groupcomm/client/GroupCommConnection.java
@@ -106,10 +106,10 @@ public class GroupCommConnection implements VanillaCommClientListener {
 	}
 	
 	public int getServerCount() {
-		return commClient.getServerCount();
+		return VanillaCommClient.getServerCount();
 	}
 	
 	public int getClientCount() {
-		return commClient.getClientCount();
+		return VanillaCommClient.getClientCount();
 	}
 }

--- a/src/main/java/org/elasql/remote/groupcomm/server/ConnectionMgr.java
+++ b/src/main/java/org/elasql/remote/groupcomm/server/ConnectionMgr.java
@@ -38,14 +38,16 @@ import org.vanilladb.core.remote.storedprocedure.SpResultSet;
 
 public class ConnectionMgr implements VanillaCommServerListener {
 	private static Logger logger = Logger.getLogger(ConnectionMgr.class.getName());
+	
+	public static final int SEQUENCER_ID = VanillaCommServer.getServerCount() - 1;
 
 	private VanillaCommServer commServer;
 	private boolean sequencerMode;
 	private BlockingQueue<List<Serializable>> tomSendQueue = new LinkedBlockingQueue<List<Serializable>>();
 	private boolean areAllServersReady = false;
 
-	public ConnectionMgr(int id, boolean seqMode) {
-		sequencerMode = seqMode;
+	public ConnectionMgr(int id) {
+		sequencerMode = Elasql.serverId() == SEQUENCER_ID;
 		commServer = new VanillaCommServer(id, this);
 		new Thread(null, commServer, "VanillaComm-Server").start();
 

--- a/src/main/java/org/elasql/schedule/calvin/CalvinScheduler.java
+++ b/src/main/java/org/elasql/schedule/calvin/CalvinScheduler.java
@@ -80,7 +80,7 @@ public class CalvinScheduler extends Task implements Scheduler {
 //				timer.stopComponentTimer(sp.getClass().getSimpleName() + " prepare");
 				
 				// The sequencer does not go further
-				if (Elasql.isSequencer()) 
+				if (Elasql.isStandAloneSequencer()) 
 					continue;
 	
 				// log request

--- a/src/main/java/org/elasql/schedule/tpart/TPartScheduler.java
+++ b/src/main/java/org/elasql/schedule/tpart/TPartScheduler.java
@@ -27,18 +27,18 @@ import org.elasql.util.ElasqlProperties;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.server.task.Task;
 
-public class TPartPartitioner extends Task implements Scheduler {
-	private static Logger logger = Logger.getLogger(TPartPartitioner.class.getName());
+public class TPartScheduler extends Task implements Scheduler {
+	private static Logger logger = Logger.getLogger(TPartScheduler.class.getName());
 
-	private static final int NUM_TASK_PER_SINK;
+	private static final int SCHEDULE_BATCH_SIZE;
 
 	private TPartStoredProcedureFactory factory;
 	
 //	private File dumpDir = new File("batch_dump");
 
 	static {
-		NUM_TASK_PER_SINK = ElasqlProperties.getLoader()
-				.getPropertyAsInteger(TPartPartitioner.class.getName() + ".NUM_TASK_PER_SINK", 10);
+		SCHEDULE_BATCH_SIZE = ElasqlProperties.getLoader()
+				.getPropertyAsInteger(TPartScheduler.class.getName() + ".SCHEDULE_BATCH_SIZE", 10);
 	}
 
 	private BlockingQueue<StoredProcedureCall> spcQueue;
@@ -47,12 +47,12 @@ public class TPartPartitioner extends Task implements Scheduler {
 	private TGraph graph;
 	private boolean batchingEnabled = true;
 
-	public TPartPartitioner(TPartStoredProcedureFactory factory, 
+	public TPartScheduler(TPartStoredProcedureFactory factory, 
 			BatchNodeInserter inserter, Sinker sinker, TGraph graph) {
 		this(factory, inserter, sinker, graph, true);
 	}
 	
-	public TPartPartitioner(TPartStoredProcedureFactory factory, 
+	public TPartScheduler(TPartStoredProcedureFactory factory, 
 			BatchNodeInserter inserter, Sinker sinker, TGraph graph,
 			boolean isBatching) {
 		this.factory = factory;
@@ -106,7 +106,7 @@ public class TPartPartitioner extends Task implements Scheduler {
 				}
 				
 				// sink current t-graph if # pending tx exceeds threshold
-				if ((batchingEnabled && batchedTasks.size() >= NUM_TASK_PER_SINK)
+				if ((batchingEnabled && batchedTasks.size() >= SCHEDULE_BATCH_SIZE)
 						|| !batchingEnabled) {
 					processBatch(batchedTasks);
 					batchedTasks.clear();

--- a/src/main/java/org/elasql/server/Elasql.java
+++ b/src/main/java/org/elasql/server/Elasql.java
@@ -36,7 +36,7 @@ import org.elasql.schedule.naive.NaiveScheduler;
 import org.elasql.schedule.tpart.BatchNodeInserter;
 import org.elasql.schedule.tpart.CostAwareNodeInserter;
 import org.elasql.schedule.tpart.LocalFirstNodeInserter;
-import org.elasql.schedule.tpart.TPartPartitioner;
+import org.elasql.schedule.tpart.TPartScheduler;
 import org.elasql.schedule.tpart.graph.TGraph;
 import org.elasql.schedule.tpart.hermes.FusionSinker;
 import org.elasql.schedule.tpart.hermes.FusionTGraph;
@@ -278,7 +278,7 @@ public class Elasql extends VanillaDb {
 		
 		// TODO: Uncomment this when the migration module is migrated
 //		factory = new MigrationStoredProcFactory(factory);
-		TPartPartitioner scheduler = new TPartPartitioner(factory,  inserter,
+		TPartScheduler scheduler = new TPartScheduler(factory,  inserter,
 				sinker, graph, isBatching);
 		
 		taskMgr().runTask(scheduler);

--- a/src/main/java/org/elasql/storage/metadata/PartitionMetaMgr.java
+++ b/src/main/java/org/elasql/storage/metadata/PartitionMetaMgr.java
@@ -18,9 +18,10 @@ package org.elasql.storage.metadata;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.elasql.server.Elasql;
 import org.elasql.sql.PartitioningKey;
 import org.elasql.sql.PrimaryKey;
-import org.elasql.util.ElasqlProperties;
+import org.vanilladb.comm.server.VanillaCommServer;
 
 public class PartitionMetaMgr {
 	private static Logger logger = Logger.getLogger(PartitionMetaMgr.class.getName());
@@ -28,8 +29,11 @@ public class PartitionMetaMgr {
 	public static final int NUM_PARTITIONS;
 
 	static {
-		NUM_PARTITIONS = ElasqlProperties.getLoader()
-				.getPropertyAsInteger(PartitionMetaMgr.class.getName() + ".NUM_PARTITIONS", 1);
+		if (Elasql.ENABLE_STAND_ALONE_SEQUENCER) {
+			NUM_PARTITIONS = VanillaCommServer.getServerCount() - 1;
+		} else {
+			NUM_PARTITIONS = VanillaCommServer.getServerCount();
+		}
 	}
 
 	private PartitionPlan partPlan;

--- a/src/main/resources/org/elasql/elasql.properties
+++ b/src/main/resources/org/elasql/elasql.properties
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###############################################################################
+
 # 
 # ElaSQL configuration file
 # 
@@ -36,10 +37,15 @@
 # 4 - G-Store style partitioned d.d. database
 # 5 - LEAP style partitioned d.d. database
 org.elasql.server.Elasql.SERVICE_TYPE=1
-
 # The partition metadata manager
 org.elasql.server.Elasql.DEFAULT_PARTITION_PLAN=org.elasql.storage.metadata.HashPartitionPlan
-
+# Decides if there is a stand-alone sequencer.
+# A stand-alone sequencer is a server that focus on coordination between servers and leading
+# group communication. The sequencer will not work as a database server, which means that
+# it will not process any query or store any data.
+# If this option is enabled, the last server on the communication list will be chosen as 
+# the stand-alone sequencer.
+org.elasql.server.Elasql.ENABLE_STAND_ALONE_SEQUENCER=false
 
 #
 # Cache package settings
@@ -126,3 +132,6 @@ org.elasql.migration.mgcrab.MgcrabSettings.START_CAUGHT_UP_DELAY=105000
 
 # The name of the log file
 org.elasql.storage.log.DdLogMgr.LOG_FILE=elasql.log
+# To disable the logging mechanism in the storage engine.
+# Note that request logging will still work even if this is set to true.
+org.elasql.storage.tx.recovery.DdRecoveryMgr.DISABLE_STORAGE_LOGGING=false

--- a/src/main/resources/org/elasql/elasql.properties
+++ b/src/main/resources/org/elasql/elasql.properties
@@ -27,7 +27,6 @@
 #
 # Server package settings
 #
-
 # The type of transaction execution engine.
 # Currently supported types:
 # 0 - Fully replicated d.d. database
@@ -59,7 +58,6 @@ org.elasql.cache.calvin.CalvinPostOffice.NUM_DISPATCHERS=1
 #
 # Schedule package settings
 #
-
 # Set the default stored procedure factory classes if no one is assigned.
 org.elasql.schedule.naive.NaiveScheduler.FACTORY_CLASS=
 org.elasql.schedule.calvin.CalvinScheduler.FACTORY_CLASS=
@@ -68,19 +66,24 @@ org.elasql.schedule.calvin.CalvinScheduler.FACTORY_CLASS=
 #
 # T-Part package settings
 #
-org.elasql.schedule.tpart.TPartPartitioner.NUM_TASK_PER_SINK=10
+# Set the size of a batch for scheduling at once
+org.elasql.schedule.tpart.TPartScheduler.SCHEDULE_BATCH_SIZE=10
+# Set the parameter for T-Part routing strategy
 org.elasql.schedule.tpart.CostAwareNodeInserter.BETA=1.0
+# Set the expected max size for the fusion table.
+# Note that the actual size may exceed this setting a little bit.
 org.elasql.schedule.tpart.hermes.FusionTable.EXPECTED_MAX_SIZE=100000
+# Set the parameter for Hermes routing strategy
 org.elasql.schedule.tpart.hermes.HermesNodeInserter.IMBALANCED_TOLERANCE=0.25
 
 
 #
 # Communication package settings
 #
-
-# The number of requests in a batch. If the # of real requests is less than
-# batch size, the no operation request will be pended in that batch.
-org.elasql.remote.groupcomm.client.BatchSpcSender.BATCH_SIZE=1
+# The number of requests in a batch for total ordering. If the # of real 
+# requests is less than the batch size, the no operation request will be 
+# pended in that batch.
+org.elasql.remote.groupcomm.client.BatchSpcSender.COMM_BATCH_SIZE=1
 org.elasql.remote.groupcomm.client.BatchSpcSender.MAX_WAITING_TIME=1000
 
 

--- a/src/main/resources/org/elasql/elasql.properties
+++ b/src/main/resources/org/elasql/elasql.properties
@@ -37,7 +37,7 @@
 # 4 - G-Store style partitioned d.d. database
 # 5 - LEAP style partitioned d.d. database
 org.elasql.server.Elasql.SERVICE_TYPE=1
-# The partition metadata manager
+# Set the default partitioning plan if no one is assigned.
 org.elasql.server.Elasql.DEFAULT_PARTITION_PLAN=org.elasql.storage.metadata.HashPartitionPlan
 # Decides if there is a stand-alone sequencer.
 # A stand-alone sequencer is a server that focus on coordination between servers and leading
@@ -47,9 +47,12 @@ org.elasql.server.Elasql.DEFAULT_PARTITION_PLAN=org.elasql.storage.metadata.Hash
 # the stand-alone sequencer.
 org.elasql.server.Elasql.ENABLE_STAND_ALONE_SEQUENCER=false
 
+
 #
 # Cache package settings
 #
+# Set the number of dispatchers for dispatching records
+# from other machines to corresponding transactions.
 org.elasql.cache.calvin.CalvinPostOffice.NUM_DISPATCHERS=1
 
 
@@ -57,15 +60,9 @@ org.elasql.cache.calvin.CalvinPostOffice.NUM_DISPATCHERS=1
 # Schedule package settings
 #
 
-# The stored procedure factory class of different types of scheduler
+# Set the default stored procedure factory classes if no one is assigned.
 org.elasql.schedule.naive.NaiveScheduler.FACTORY_CLASS=
 org.elasql.schedule.calvin.CalvinScheduler.FACTORY_CLASS=
-
-
-#
-# Metadata package settings
-#
-org.elasql.storage.metadata.PartitionMetaMgr.NUM_PARTITIONS=1
 
 
 #


### PR DESCRIPTION
Update the following properties:

- Add a property to enable stand-alone sequencer
- Add a property to disable storage logging
- Rename `org.elasql.remote.groupcomm.client.BatchSpcSender.BATCH_SIZE` to `org.elasql.remote.groupcomm.client.BatchSpcSender.COMM_BATCH_SIZE`
- Rename `org.elasql.schedule.tpart.TPartPartitioner.NUM_TASK_PER_SINK` to `org.elasql.schedule.tpart.TPartPartitioner.SCHEDULE_BATCH_SIZE`
- Remove property `org.elasql.storage.metadata.PartitionMetaMgr.NUM_PARTITIONS` because ElaSQL will set this property automatically now