### PR TITLE
Add a method in PerformanceManager to get the instance of MetricWarehouse

### DIFF
--- a/src/main/java/org/elasql/perf/DummyPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/DummyPerformanceManager.java
@@ -1,6 +1,6 @@
 package org.elasql.perf;
 
-import org.elasql.perf.tpart.metric.MetricWarehouse;
+import org.elasql.perf.tpart.metric.TpartMetricWarehouse;
 import org.elasql.remote.groupcomm.StoredProcedureCall;
 import org.vanilladb.core.util.TransactionProfiler;
 

--- a/src/main/java/org/elasql/perf/DummyPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/DummyPerformanceManager.java
@@ -1,5 +1,6 @@
 package org.elasql.perf;
 
+import org.elasql.perf.tpart.metric.MetricWarehouse;
 import org.elasql.remote.groupcomm.StoredProcedureCall;
 import org.vanilladb.core.util.TransactionProfiler;
 
@@ -10,7 +11,6 @@ import org.vanilladb.core.util.TransactionProfiler;
  * @author Yu-Shan Lin
  */
 public class DummyPerformanceManager implements PerformanceManager {
-
 	@Override
 	public void monitorTransaction(StoredProcedureCall spc) {
 		// Do nothing
@@ -24,5 +24,10 @@ public class DummyPerformanceManager implements PerformanceManager {
 	@Override
 	public void receiveMetricReport(MetricReport report) {
 		// Do nothing
+	}
+	
+	@Override
+	public MetricWarehouse getMetricWarehouse() {
+		throw new RuntimeException("Invalid function call on a dummy performance manager");
 	}
 }

--- a/src/main/java/org/elasql/perf/MetricWarehouse.java
+++ b/src/main/java/org/elasql/perf/MetricWarehouse.java
@@ -1,0 +1,5 @@
+package org.elasql.perf;
+
+public interface MetricWarehouse {
+
+}

--- a/src/main/java/org/elasql/perf/PerformanceManager.java
+++ b/src/main/java/org/elasql/perf/PerformanceManager.java
@@ -1,6 +1,5 @@
 package org.elasql.perf;
 
-import org.elasql.perf.tpart.metric.MetricWarehouse;
 import org.elasql.remote.groupcomm.StoredProcedureCall;
 import org.vanilladb.core.util.TransactionProfiler;
 

--- a/src/main/java/org/elasql/perf/PerformanceManager.java
+++ b/src/main/java/org/elasql/perf/PerformanceManager.java
@@ -1,5 +1,6 @@
 package org.elasql.perf;
 
+import org.elasql.perf.tpart.metric.MetricWarehouse;
 import org.elasql.remote.groupcomm.StoredProcedureCall;
 import org.vanilladb.core.util.TransactionProfiler;
 
@@ -35,4 +36,9 @@ public interface PerformanceManager {
 	 * @param report the metric report
 	 */
 	void receiveMetricReport(MetricReport report);
+	
+	/**
+	 * Get the instance of MetricWarehouse.
+	 */
+	MetricWarehouse getMetricWarehouse();
 }

--- a/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
@@ -1,11 +1,12 @@
 package org.elasql.perf.tpart;
 
 import org.elasql.perf.MetricReport;
+import org.elasql.perf.MetricWarehouse;
 import org.elasql.perf.PerformanceManager;
 import org.elasql.perf.tpart.ai.Estimator;
 import org.elasql.perf.tpart.metric.MetricCollector;
-import org.elasql.perf.tpart.metric.MetricWarehouse;
 import org.elasql.perf.tpart.metric.TPartSystemMetrics;
+import org.elasql.perf.tpart.metric.TpartMetricWarehouse;
 import org.elasql.perf.tpart.workload.FeatureCollector;
 import org.elasql.procedure.tpart.TPartStoredProcedureFactory;
 import org.elasql.remote.groupcomm.StoredProcedureCall;
@@ -16,7 +17,7 @@ public class TPartPerformanceManager implements PerformanceManager {
 
 	// On the sequencer
 	private FeatureCollector featureCollector;
-	private MetricWarehouse metricWarehouse;
+	private TpartMetricWarehouse metricWarehouse;
 	
 	// On each DB machine
 	private MetricCollector localMetricCollector;
@@ -28,7 +29,7 @@ public class TPartPerformanceManager implements PerformanceManager {
 				featureCollector = new FeatureCollector(factory);
 				Elasql.taskMgr().runTask(featureCollector);
 				
-				metricWarehouse = new MetricWarehouse();
+				metricWarehouse = new TpartMetricWarehouse();
 				Elasql.taskMgr().runTask(metricWarehouse);
 			} else {
 				localMetricCollector = new MetricCollector();

--- a/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
@@ -35,7 +35,7 @@ public class TPartPerformanceManager implements PerformanceManager {
 				Elasql.taskMgr().runTask(localMetricCollector);
 			}
 		}
-	}
+	} 
 
 	@Override
 	public void monitorTransaction(StoredProcedureCall spc) {
@@ -58,5 +58,10 @@ public class TPartPerformanceManager implements PerformanceManager {
 	@Override
 	public void receiveMetricReport(MetricReport report) {
 		metricWarehouse.receiveMetricReport((TPartSystemMetrics) report);
+	}
+	
+	@Override
+	public MetricWarehouse getMetricWarehouse() {
+		return metricWarehouse;
 	}
 }

--- a/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
@@ -5,16 +5,17 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import org.elasql.perf.MetricWarehouse;
 import org.vanilladb.core.server.task.Task;
 
-public class MetricWarehouse extends Task {
+public class TpartMetricWarehouse extends Task implements MetricWarehouse {
 
 	private BlockingQueue<TPartSystemMetrics> metricQueue;
 	
 	// XXX: for demo
 	private Map<Integer, Integer> fakeMetrics;
 	
-	public MetricWarehouse() {
+	public TpartMetricWarehouse() {
 		this.metricQueue = new LinkedBlockingQueue<TPartSystemMetrics>();
 		this.fakeMetrics = new HashMap<Integer, Integer>();
 	}


### PR DESCRIPTION
Just add a simple method to get the instance of MetricWarehouse.

Let me know if this could be better. Thanks.