### PR TITLE
Previous FeatureExtractor wiill access null `MetricWarehouse`

### DIFF
--- a/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
@@ -25,12 +25,12 @@ public class TPartPerformanceManager implements PerformanceManager {
 	public TPartPerformanceManager(TPartStoredProcedureFactory factory) {
 		if (Estimator.ENABLE_COLLECTING_DATA) {
 			if (Elasql.isStandAloneSequencer()) {
-				// The sequencer maintains a feature collector and a warehouse
-				featureCollector = new FeatureCollector(factory);
-				Elasql.taskMgr().runTask(featureCollector);
-				
 				metricWarehouse = new TpartMetricWarehouse();
 				Elasql.taskMgr().runTask(metricWarehouse);
+				
+				// The sequencer maintains a feature collector and a warehouse
+				featureCollector = new FeatureCollector(factory, metricWarehouse);
+				Elasql.taskMgr().runTask(featureCollector);
 			} else {
 				localMetricCollector = new MetricCollector();
 				Elasql.taskMgr().runTask(localMetricCollector);

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureCollector.java
@@ -3,6 +3,7 @@ package org.elasql.perf.tpart.workload;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import org.elasql.perf.tpart.metric.TpartMetricWarehouse;
 import org.elasql.procedure.tpart.TPartStoredProcedure;
 import org.elasql.procedure.tpart.TPartStoredProcedureFactory;
 import org.elasql.procedure.tpart.TPartStoredProcedureTask;
@@ -22,11 +23,11 @@ public class FeatureCollector extends Task {
 	private TransactionFeaturesRecorder featureRecorder;
 	private TransactionDependencyRecorder dependencyRecorder;
 	
-	public FeatureCollector(TPartStoredProcedureFactory factory) {
+	public FeatureCollector(TPartStoredProcedureFactory factory, TpartMetricWarehouse metricWarehouse) {
 		this.factory = factory;
 		this.spcQueue = new LinkedBlockingQueue<StoredProcedureCall>();
 		
-		featureExtractor = new FeatureExtractor();
+		featureExtractor = new FeatureExtractor(metricWarehouse);
 		featureRecorder = new TransactionFeaturesRecorder();
 		featureRecorder.startRecording();
 		dependencyRecorder = new TransactionDependencyRecorder();

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -2,6 +2,7 @@ package org.elasql.perf.tpart.workload;
 
 import java.util.Set;
 
+import org.elasql.perf.tpart.metric.TpartMetricWarehouse;
 import org.elasql.procedure.tpart.TPartStoredProcedureTask;
 
 /**
@@ -16,6 +17,12 @@ public class FeatureExtractor {
 	
 	private TransactionDependencyAnalyzer dependencyAnalyzer =
 			new TransactionDependencyAnalyzer();
+	
+	private TpartMetricWarehouse metricWarehouse;
+	
+	public FeatureExtractor(TpartMetricWarehouse metricWarehouse) {
+		this.metricWarehouse = metricWarehouse;
+	}
 	
 	public TransactionFeatures extractFeatures(TPartStoredProcedureTask task) {
 		// Check if transaction requests are given in the total order


### PR DESCRIPTION
In `FeatureExtractor`,
we are not able to get `metricWarehouse` by using `Elasql.PerformanceManager.getMetricWarehouse()`,
 because the `performanceManager` is initializing and a reference cycle exists.

Therefore,  Passing `metricWarehouse` into `FeatureExtractor` might be proper.