### PR TITLE
Make `FeatureExtractor` gain access to `TxNode`

### DIFF
--- a/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
@@ -10,6 +10,9 @@ import org.elasql.perf.tpart.metric.TpartMetricWarehouse;
 import org.elasql.perf.tpart.workload.FeatureCollector;
 import org.elasql.procedure.tpart.TPartStoredProcedureFactory;
 import org.elasql.remote.groupcomm.StoredProcedureCall;
+import org.elasql.schedule.tpart.BatchNodeInserter;
+import org.elasql.schedule.tpart.graph.TGraph;
+import org.elasql.schedule.tpart.sink.Sinker;
 import org.elasql.server.Elasql;
 import org.vanilladb.core.util.TransactionProfiler;
 
@@ -22,14 +25,17 @@ public class TPartPerformanceManager implements PerformanceManager {
 	// On each DB machine
 	private MetricCollector localMetricCollector;
 	
-	public TPartPerformanceManager(TPartStoredProcedureFactory factory) {
+	public TPartPerformanceManager(TPartStoredProcedureFactory factory, 
+			BatchNodeInserter inserter, Sinker sinker, TGraph graph,
+			boolean isBatching) {
 		if (Estimator.ENABLE_COLLECTING_DATA) {
 			if (Elasql.isStandAloneSequencer()) {
 				metricWarehouse = new TpartMetricWarehouse();
 				Elasql.taskMgr().runTask(metricWarehouse);
 				
 				// The sequencer maintains a feature collector and a warehouse
-				featureCollector = new FeatureCollector(factory, metricWarehouse);
+				featureCollector = new FeatureCollector(factory, inserter,
+						sinker, graph, isBatching, metricWarehouse);
 				Elasql.taskMgr().runTask(featureCollector);
 			} else {
 				localMetricCollector = new MetricCollector();

--- a/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
@@ -12,7 +12,6 @@ import org.elasql.procedure.tpart.TPartStoredProcedureFactory;
 import org.elasql.remote.groupcomm.StoredProcedureCall;
 import org.elasql.schedule.tpart.BatchNodeInserter;
 import org.elasql.schedule.tpart.graph.TGraph;
-import org.elasql.schedule.tpart.sink.Sinker;
 import org.elasql.server.Elasql;
 import org.vanilladb.core.util.TransactionProfiler;
 
@@ -26,7 +25,7 @@ public class TPartPerformanceManager implements PerformanceManager {
 	private MetricCollector localMetricCollector;
 	
 	public TPartPerformanceManager(TPartStoredProcedureFactory factory, 
-			BatchNodeInserter inserter, Sinker sinker, TGraph graph,
+			BatchNodeInserter inserter, TGraph graph,
 			boolean isBatching) {
 		if (Estimator.ENABLE_COLLECTING_DATA) {
 			if (Elasql.isStandAloneSequencer()) {
@@ -35,7 +34,7 @@ public class TPartPerformanceManager implements PerformanceManager {
 				
 				// The sequencer maintains a feature collector and a warehouse
 				featureCollector = new FeatureCollector(factory, inserter,
-						sinker, graph, isBatching, metricWarehouse);
+						graph, isBatching, metricWarehouse);
 				Elasql.taskMgr().runTask(featureCollector);
 			} else {
 				localMetricCollector = new MetricCollector();

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureCollector.java
@@ -1,13 +1,22 @@
 package org.elasql.perf.tpart.workload;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.elasql.perf.tpart.metric.TpartMetricWarehouse;
 import org.elasql.procedure.tpart.TPartStoredProcedure;
+import org.elasql.procedure.tpart.TPartStoredProcedure.ProcedureType;
 import org.elasql.procedure.tpart.TPartStoredProcedureFactory;
 import org.elasql.procedure.tpart.TPartStoredProcedureTask;
 import org.elasql.remote.groupcomm.StoredProcedureCall;
+import org.elasql.schedule.tpart.BatchNodeInserter;
+import org.elasql.schedule.tpart.TPartScheduler;
+import org.elasql.schedule.tpart.graph.TGraph;
+import org.elasql.schedule.tpart.sink.Sinker;
+import org.elasql.schedule.tpart.sink.SunkPlan;
 import org.vanilladb.core.server.task.Task;
 
 /**
@@ -16,42 +25,75 @@ import org.vanilladb.core.server.task.Task;
  * @author Yu-Shan Lin
  */
 public class FeatureCollector extends Task {
-
-	private TPartStoredProcedureFactory factory;
+	
 	private BlockingQueue<StoredProcedureCall> spcQueue;
 	private FeatureExtractor featureExtractor;
 	private TransactionFeaturesRecorder featureRecorder;
 	private TransactionDependencyRecorder dependencyRecorder;
+
+	// Components to simulate the scheduler
+	private TPartStoredProcedureFactory factory;
+	private BatchNodeInserter inserter;
+	private Sinker sinker;
+	private TGraph graph;
+	private boolean isBatching;
 	
-	public FeatureCollector(TPartStoredProcedureFactory factory, TpartMetricWarehouse metricWarehouse) {
+	public FeatureCollector(TPartStoredProcedureFactory factory, 
+			BatchNodeInserter inserter, Sinker sinker, TGraph graph,
+			boolean isBatching, TpartMetricWarehouse metricWarehouse) {
+		
+		// For generating execution plan and sp task
 		this.factory = factory;
+		this.inserter = inserter;
+		this.sinker = sinker;
+		this.graph = graph;
+		this.isBatching = isBatching;
 		this.spcQueue = new LinkedBlockingQueue<StoredProcedureCall>();
+		
+		// For collecting features
 		featureExtractor = new FeatureExtractor(metricWarehouse);
 		featureRecorder = new TransactionFeaturesRecorder();
 		featureRecorder.startRecording();
 		dependencyRecorder = new TransactionDependencyRecorder();
 		dependencyRecorder.startRecording();
 	}
+	
+	public void monitorTransaction(StoredProcedureCall spc) {
+		if (!spc.isNoOpStoredProcCall())
+			spcQueue.add(spc);
+	}
 
 	@Override
 	public void run() {
+		List<TPartStoredProcedureTask> batchedTasks = 
+				new ArrayList<TPartStoredProcedureTask>();
+		
 		Thread.currentThread().setName("feature-collector");
 		
 		while (true) {
 			try {
+				// Take a SP call
 				StoredProcedureCall spc = spcQueue.take();
+				
+				// Queue to the batch
 				TPartStoredProcedureTask task = convertToSpTask(spc);
-				TransactionFeatures features = featureExtractor.extractFeatures(task);
-				featureRecorder.record(features);
-				dependencyRecorder.record(features);
+				if (task.getProcedureType() == ProcedureType.NORMAL)
+					batchedTasks.add(task);
+				
+				// Process the batch as TPartScheduler does
+				if ((isBatching && batchedTasks.size() >= TPartScheduler.SCHEDULE_BATCH_SIZE)
+						|| !isBatching) {
+					Iterator<TPartStoredProcedureTask> iter = processBatch(batchedTasks);
+					if (iter != null) {
+						while (iter.hasNext())
+							recordFeatures(iter.next());
+					}
+					batchedTasks.clear();
+				}
 			} catch (InterruptedException e) {
 				e.printStackTrace();
 			}
 		}
-	}
-	
-	public void monitorTransaction(StoredProcedureCall spc) {
-		spcQueue.add(spc);
 	}
 	
 	private TPartStoredProcedureTask convertToSpTask(StoredProcedureCall spc) {
@@ -63,5 +105,25 @@ public class FeatureCollector extends Task {
 		}
 		
 		return null;
+	}
+	
+	private Iterator<TPartStoredProcedureTask> processBatch(
+			List<TPartStoredProcedureTask> batchedTasks) {
+		// Insert the batch of tasks
+		inserter.insertBatch(graph, batchedTasks);
+		
+		// Sink the graph
+		if (graph.getTxNodes().size() != 0) {
+			return sinker.sink(graph);
+		}
+		
+		return null;
+	}
+	
+	private void recordFeatures(TPartStoredProcedureTask task) {
+		SunkPlan plan = task.getProcedure().getSunkPlan();
+		TransactionFeatures features = featureExtractor.extractFeatures(task, plan);
+		featureRecorder.record(features);
+		dependencyRecorder.record(features);
 	}
 }

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureCollector.java
@@ -1,7 +1,6 @@
 package org.elasql.perf.tpart.workload;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -15,8 +14,7 @@ import org.elasql.remote.groupcomm.StoredProcedureCall;
 import org.elasql.schedule.tpart.BatchNodeInserter;
 import org.elasql.schedule.tpart.TPartScheduler;
 import org.elasql.schedule.tpart.graph.TGraph;
-import org.elasql.schedule.tpart.sink.Sinker;
-import org.elasql.schedule.tpart.sink.SunkPlan;
+import org.elasql.schedule.tpart.graph.TxNode;
 import org.vanilladb.core.server.task.Task;
 
 /**
@@ -34,18 +32,16 @@ public class FeatureCollector extends Task {
 	// Components to simulate the scheduler
 	private TPartStoredProcedureFactory factory;
 	private BatchNodeInserter inserter;
-	private Sinker sinker;
 	private TGraph graph;
 	private boolean isBatching;
 	
 	public FeatureCollector(TPartStoredProcedureFactory factory, 
-			BatchNodeInserter inserter, Sinker sinker, TGraph graph,
+			BatchNodeInserter inserter, TGraph graph,
 			boolean isBatching, TpartMetricWarehouse metricWarehouse) {
 		
 		// For generating execution plan and sp task
 		this.factory = factory;
 		this.inserter = inserter;
-		this.sinker = sinker;
 		this.graph = graph;
 		this.isBatching = isBatching;
 		this.spcQueue = new LinkedBlockingQueue<StoredProcedureCall>();
@@ -83,11 +79,7 @@ public class FeatureCollector extends Task {
 				// Process the batch as TPartScheduler does
 				if ((isBatching && batchedTasks.size() >= TPartScheduler.SCHEDULE_BATCH_SIZE)
 						|| !isBatching) {
-					Iterator<TPartStoredProcedureTask> iter = processBatch(batchedTasks);
-					if (iter != null) {
-						while (iter.hasNext())
-							recordFeatures(iter.next());
-					}
+					processBatch(batchedTasks);
 					batchedTasks.clear();
 				}
 			} catch (InterruptedException e) {
@@ -107,23 +99,21 @@ public class FeatureCollector extends Task {
 		return null;
 	}
 	
-	private Iterator<TPartStoredProcedureTask> processBatch(
-			List<TPartStoredProcedureTask> batchedTasks) {
+	private void processBatch(List<TPartStoredProcedureTask> batchedTasks) {
 		// Insert the batch of tasks
 		inserter.insertBatch(graph, batchedTasks);
 		
-		// Sink the graph
-		if (graph.getTxNodes().size() != 0) {
-			return sinker.sink(graph);
+		// add write back edges
+		graph.addWriteBackEdge();
+		
+		// Record the features for each transaction
+		for (TxNode node : graph.getTxNodes()) {
+			TransactionFeatures features = featureExtractor.extractFeatures(node);
+			featureRecorder.record(features);
+			dependencyRecorder.record(features);
 		}
 		
-		return null;
-	}
-	
-	private void recordFeatures(TPartStoredProcedureTask task) {
-		SunkPlan plan = task.getProcedure().getSunkPlan();
-		TransactionFeatures features = featureExtractor.extractFeatures(task, plan);
-		featureRecorder.record(features);
-		dependencyRecorder.record(features);
+		// Clean up the tx nodes
+		graph.clear();
 	}
 }

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -1,10 +1,14 @@
 package org.elasql.perf.tpart.workload;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import org.elasql.perf.tpart.metric.TpartMetricWarehouse;
 import org.elasql.procedure.tpart.TPartStoredProcedureTask;
-import org.elasql.schedule.tpart.sink.SunkPlan;
+import org.elasql.schedule.tpart.graph.Edge;
+import org.elasql.schedule.tpart.graph.TxNode;
+import org.elasql.server.Elasql;
+import org.elasql.sql.PrimaryKey;
 import org.elasql.storage.metadata.PartitionMetaMgr;
 
 /**
@@ -26,14 +30,16 @@ public class FeatureExtractor {
 		this.metricWarehouse = metricWarehouse;
 	}
 	
-	public TransactionFeatures extractFeatures(TPartStoredProcedureTask task,
-			SunkPlan executionPlan) {
+	public TransactionFeatures extractFeatures(TxNode txNode) {
 		// Check if transaction requests are given in the total order
-		if (task.getTxNum() <= lastProcessedTxNum)
+		if (txNode.getTxNum() <= lastProcessedTxNum)
 			throw new RuntimeException(String.format(
 					"Transaction requests are not passed to FeatureExtractor "
 					+ "in the total order: %d, last processed tx: %d",
-					task.getTxNum(), lastProcessedTxNum));
+					txNode.getTxNum(), lastProcessedTxNum));
+		
+		// Get the task
+		TPartStoredProcedureTask task = txNode.getTask();
 		
 		// Extract the features
 		TransactionFeatures.Builder builder = new TransactionFeatures.Builder(task.getTxNum());
@@ -42,6 +48,8 @@ public class FeatureExtractor {
 		builder.addFeature("Start Time", task.getArrivedTime());
 		builder.addFeature("Number of Read Records", task.getReadSet().size());
 		builder.addFeature("Number of Write Records", task.getWriteSet().size());
+		builder.addFeature("Number of Cache Writes per Server", extractCacheWrites(txNode));
+		builder.addFeature("Number of Storage Writes per Server", extractStorageWrites(txNode));
 
 		// Features below are from the servers
 		extractSystemCpuLoad(builder);
@@ -104,5 +112,41 @@ public class FeatureExtractor {
 					serverId
 				);
 		}
+	}
+	
+	private String extractCacheWrites(TxNode node) {
+		PartitionMetaMgr partMeta = Elasql.partitionMetaMgr();
+		int[] counts = new int[PartitionMetaMgr.NUM_PARTITIONS];
+		
+		// Write: pass to the next transactions
+		for (Edge writeEdge : node.getWriteEdges()) {
+			int partId = writeEdge.getTarget().getPartId();
+			counts[partId]++;
+		}
+		
+		// Writeback: save on the local cache or storage
+		for (Edge writeEdge : node.getWriteBackEdges()) {
+			PrimaryKey key = writeEdge.getResourceKey();
+			int partId = writeEdge.getTarget().getPartId();
+			if (!partMeta.isFullyReplicated(key) && partMeta.getPartition(key) != partId)
+				counts[partId]++;
+		}
+		
+		return Arrays.toString(counts);
+	}
+	
+	private String extractStorageWrites(TxNode node) {
+		PartitionMetaMgr partMeta = Elasql.partitionMetaMgr();
+		int[] counts = new int[PartitionMetaMgr.NUM_PARTITIONS];
+		
+		// Only writeback write to storage
+		for (Edge writeEdge : node.getWriteBackEdges()) {
+			PrimaryKey key = writeEdge.getResourceKey();
+			int partId = writeEdge.getTarget().getPartId();
+			if (partMeta.isFullyReplicated(key) || partMeta.getPartition(key) == partId)
+				counts[partId]++;
+		}
+		
+		return Arrays.toString(counts);
 	}
 }

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.elasql.perf.tpart.metric.TpartMetricWarehouse;
 import org.elasql.procedure.tpart.TPartStoredProcedureTask;
+import org.elasql.schedule.tpart.sink.SunkPlan;
 import org.elasql.storage.metadata.PartitionMetaMgr;
 
 /**
@@ -25,14 +26,15 @@ public class FeatureExtractor {
 		this.metricWarehouse = metricWarehouse;
 	}
 	
-	public TransactionFeatures extractFeatures(TPartStoredProcedureTask task) {
+	public TransactionFeatures extractFeatures(TPartStoredProcedureTask task,
+			SunkPlan executionPlan) {
 		// Check if transaction requests are given in the total order
 		if (task.getTxNum() <= lastProcessedTxNum)
 			throw new RuntimeException(String.format(
 					"Transaction requests are not passed to FeatureExtractor "
 					+ "in the total order: %d, last processed tx: %d",
 					task.getTxNum(), lastProcessedTxNum));
-			
+		
 		// Extract the features
 		TransactionFeatures.Builder builder = new TransactionFeatures.Builder(task.getTxNum());
 		

--- a/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
@@ -30,6 +30,10 @@ public class TransactionFeatures {
 		featureKeys.add("Number of Read Records");
 		// - Number of written records
 		featureKeys.add("Number of Write Records");
+		// - Number of writes to cache for each server
+		featureKeys.add("Number of Cache Writes per Server");
+		// - Number of writes to storage for each server
+		featureKeys.add("Number of Storage Writes per Server");
 		
 		addKeysWithServerCount(featureKeys, "System CPU Load");
 		addKeysWithServerCount(featureKeys, "Process CPU Load");

--- a/src/main/java/org/elasql/schedule/tpart/TPartScheduler.java
+++ b/src/main/java/org/elasql/schedule/tpart/TPartScheduler.java
@@ -30,7 +30,7 @@ import org.vanilladb.core.util.TransactionProfiler;
 public class TPartScheduler extends Task implements Scheduler {
 	private static Logger logger = Logger.getLogger(TPartScheduler.class.getName());
 
-	private static final int SCHEDULE_BATCH_SIZE;
+	public static final int SCHEDULE_BATCH_SIZE;
 
 	private TPartStoredProcedureFactory factory;
 	

--- a/src/main/java/org/elasql/server/Elasql.java
+++ b/src/main/java/org/elasql/server/Elasql.java
@@ -156,11 +156,10 @@ public class Elasql extends VanillaDb {
  
 		if (isStandAloneSequencer()) { 
 			logger.info("initializing as the stand alone sequencer"); 
-			VanillaDb.initTaskMgr(); 
+			VanillaDb.initTaskMgr();
+			initPartitionMetaMgr(partitionPlan); // must be before TPartPerformanceMgr
 			initPerfMgr(factory); 
-			initConnectionMgr(myNodeId); 
-			initPartitionMetaMgr(partitionPlan); 
-			initScheduler(factory, migraComsFactory); 
+			initConnectionMgr(myNodeId);
 			if (migraComsFactory != null) 
 				migraSysControl = migraComsFactory.newSystemController(); 
 			return; 
@@ -330,43 +329,38 @@ public class Elasql extends VanillaDb {
 	
 	private static TPartPerformanceManager newTPartPerfMgr(TPartStoredProcedureFactory factory) {
 		TGraph graph; 
-		BatchNodeInserter inserter; 
-		Sinker sinker; 
+		BatchNodeInserter inserter;
 		FusionTable table; 
 		boolean isBatching = true; 
 		 
 		switch (SERVICE_TYPE) { 
 		case TPART: 
 			graph = new TGraph(); 
-			inserter = new CostAwareNodeInserter(); 
-			sinker = new Sinker(); 
+			inserter = new CostAwareNodeInserter();
 			isBatching = true; 
 			break; 
 		case HERMES: 
 			table = new FusionTable(); 
 			graph = new FusionTGraph(table); 
-			inserter = new HermesNodeInserter(); 
-			sinker = new FusionSinker(table); 
+			inserter = new HermesNodeInserter();
 			isBatching = true; 
 			break; 
 		case G_STORE: 
 			graph = new TGraph(); 
-			inserter = new LocalFirstNodeInserter(); 
-			sinker = new Sinker(); 
+			inserter = new LocalFirstNodeInserter();
 			isBatching = false; 
 			break; 
 		case LEAP: 
 			table = new FusionTable(); 
 			graph = new FusionTGraph(table); 
-			inserter = new LocalFirstNodeInserter(); 
-			sinker = new FusionSinker(table); 
+			inserter = new LocalFirstNodeInserter();
 			isBatching = false; 
 			break; 
 		default: 
 			throw new IllegalArgumentException("Not supported"); 
 		} 
 		 
-		return new TPartPerformanceManager(factory, inserter, sinker, graph, isBatching); 
+		return new TPartPerformanceManager(factory, inserter, graph, isBatching); 
 	}
  
 	// ================ 


### PR DESCRIPTION
I modified the design of `FeatureExtractor` and `FeatureCollector` so that `FeatureExtractor` can now generate more features on the sequencer without communicating with other DB servers. This is done by generating an exact same `TGraph` in `FeatureCollector` and providing `TxNode` to `FeatureExtractor`.

I also added two features `Number of Cache Writes per Server` and `Number of Storage Writes per Server` to demonstrate how to extract features from `TxNode`.