### PR TITLE
Replace ArrayBlockingQueue with LinkedBlockingQueue

### DIFF
--- a/src/main/java/org/elasql/perf/tpart/workload/TransactionFeaturesRecorder.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/TransactionFeaturesRecorder.java
@@ -3,8 +3,8 @@ package org.elasql.perf.tpart.workload;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -58,7 +58,7 @@ public class TransactionFeaturesRecorder extends Task {
 	
 	private AtomicBoolean isRecording = new AtomicBoolean(false);
 	private BlockingQueue<FeatureRow> queue
-		= new ArrayBlockingQueue<FeatureRow>(1000_000);
+		= new LinkedBlockingQueue<FeatureRow>();
 	
 	public void startRecording() {
 		if (!isRecording.getAndSet(true)) {

--- a/src/main/java/org/elasql/perf/tpart/workload/TransactionFeaturesRecorder.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/TransactionFeaturesRecorder.java
@@ -58,7 +58,7 @@ public class TransactionFeaturesRecorder extends Task {
 	
 	private AtomicBoolean isRecording = new AtomicBoolean(false);
 	private BlockingQueue<FeatureRow> queue
-		= new ArrayBlockingQueue<FeatureRow>(100000);
+		= new ArrayBlockingQueue<FeatureRow>(1000_000);
 	
 	public void startRecording() {
 		if (!isRecording.getAndSet(true)) {


### PR DESCRIPTION
Errors happen when we run experiments with a greater RTE number. The element number of an arrayBlockingQueue might reach the array size.

In addition, there are several packages using arrayBlockingQueue. I think it's still OK to use them until we encounter the errors. 