### PR TITLE
Record if a transaction is distributed in metric logs

### DIFF
--- a/src/main/java/org/elasql/perf/DummyPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/DummyPerformanceManager.java
@@ -16,7 +16,7 @@ public class DummyPerformanceManager implements PerformanceManager {
 	}
 
 	@Override
-	public void addTransactionMetics(long txNum, String role, TransactionProfiler profiler) {
+	public void addTransactionMetics(long txNum, String role, boolean isTxDistributed, TransactionProfiler profiler) {
 		// Do nothing
 	}
 

--- a/src/main/java/org/elasql/perf/PerformanceManager.java
+++ b/src/main/java/org/elasql/perf/PerformanceManager.java
@@ -25,9 +25,10 @@ public interface PerformanceManager {
 	 * 
 	 * @param txNum the transaction number
 	 * @param role the role of this machine for the transaction
+	 * @param isTxDistributed true if tx is a distributed tx
 	 * @param profiler the metrics for the transaction
 	 */
-	void addTransactionMetics(long txNum, String role, TransactionProfiler profiler);
+	void addTransactionMetics(long txNum, String role, boolean isTxDistributed, TransactionProfiler profiler);
 	
 	/**
 	 * Receives the metric report coming from other database servers.

--- a/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
+++ b/src/main/java/org/elasql/perf/tpart/TPartPerformanceManager.java
@@ -53,10 +53,10 @@ public class TPartPerformanceManager implements PerformanceManager {
 	}
 
 	@Override
-	public void addTransactionMetics(long txNum, String role, TransactionProfiler profiler) {
+	public void addTransactionMetics(long txNum, String role, boolean isTxDistributed, TransactionProfiler profiler) {
 		if (Estimator.ENABLE_COLLECTING_DATA) {
 			if (!Elasql.isStandAloneSequencer()) {
-				localMetricCollector.addTransactionMetrics(txNum, role, profiler);
+				localMetricCollector.addTransactionMetrics(txNum, role, isTxDistributed, profiler);
 			}
 		}
 	}

--- a/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
@@ -26,8 +26,8 @@ public class MetricCollector extends Task {
 		metricRecorder.startRecording();
 	}
 
-	public void addTransactionMetrics(long txNum, String role, TransactionProfiler profiler) {
-		metricRecorder.addTransactionMetrics(txNum, role, profiler);
+	public void addTransactionMetrics(long txNum, String role, boolean isTxDistributed, TransactionProfiler profiler) {
+		metricRecorder.addTransactionMetrics(txNum, role, isTxDistributed, profiler);
 	}
 
 	@Override

--- a/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedure.java
+++ b/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedure.java
@@ -152,7 +152,7 @@ public abstract class TPartStoredProcedure<H extends StoredProcedureParamHelper>
 	}
 	
 	public boolean isTxDistributed() {
-		return isTxDistributed;
+		return plan.isTxDistributed();
 	}
 
 	public ProcedureType getProcedureType() {
@@ -221,7 +221,6 @@ public abstract class TPartStoredProcedure<H extends StoredProcedureParamHelper>
 			profiler.startComponentProfiler("OU5M - Read from Remote");
 			for (PrimaryKey k : plan.getReadSet()) {
 				if (!readings.containsKey(k)) {
-					isTxDistributed = true;
 					long srcTxNum = plan.getReadSrcTxNum(k);
 					readings.put(k, cache.read(k, srcTxNum));
 					cachedEntrySet.add(new CachedEntryKey(k, srcTxNum, txNum));

--- a/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedure.java
+++ b/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedure.java
@@ -47,6 +47,7 @@ public abstract class TPartStoredProcedure<H extends StoredProcedureParamHelper>
 	private TPartTxLocalCache cache;
 	private List<CachedEntryKey> cachedEntrySet = new ArrayList<CachedEntryKey>();
 	private boolean isCommitted = false;
+	private boolean isTxDistributed = false;
 
 	public TPartStoredProcedure(long txNum, H paramHelper) {
 		super(paramHelper);
@@ -149,6 +150,10 @@ public abstract class TPartStoredProcedure<H extends StoredProcedureParamHelper>
 	public boolean isMaster() {
 		return plan.isHereMaster();
 	}
+	
+	public boolean isTxDistributed() {
+		return isTxDistributed;
+	}
 
 	public ProcedureType getProcedureType() {
 		return ProcedureType.NORMAL;
@@ -216,6 +221,7 @@ public abstract class TPartStoredProcedure<H extends StoredProcedureParamHelper>
 			profiler.startComponentProfiler("OU5M - Read from Remote");
 			for (PrimaryKey k : plan.getReadSet()) {
 				if (!readings.containsKey(k)) {
+					isTxDistributed = true;
 					long srcTxNum = plan.getReadSrcTxNum(k);
 					readings.put(k, cache.read(k, srcTxNum));
 					cachedEntrySet.add(new CachedEntryKey(k, srcTxNum, txNum));

--- a/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedure.java
+++ b/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedure.java
@@ -47,7 +47,6 @@ public abstract class TPartStoredProcedure<H extends StoredProcedureParamHelper>
 	private TPartTxLocalCache cache;
 	private List<CachedEntryKey> cachedEntrySet = new ArrayList<CachedEntryKey>();
 	private boolean isCommitted = false;
-	private boolean isTxDistributed = false;
 
 	public TPartStoredProcedure(long txNum, H paramHelper) {
 		super(paramHelper);

--- a/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedureTask.java
+++ b/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedureTask.java
@@ -72,7 +72,8 @@ public class TPartStoredProcedureTask
 		
 		// Record the profiler result
 		String role = tsp.isMaster()? "Master" : "Slave";
-		Elasql.performanceMgr().addTransactionMetics(txNum, role, profiler);
+		
+		Elasql.performanceMgr().addTransactionMetics(txNum, role, tsp.isTxDistributed(), profiler);
 	}
 
 	public long getTxNum() {

--- a/src/main/java/org/elasql/schedule/tpart/sink/Sinker.java
+++ b/src/main/java/org/elasql/schedule/tpart/sink/Sinker.java
@@ -18,7 +18,7 @@ public class Sinker {
 	protected PartitionMetaMgr parMeta;
 	protected int myId = Elasql.serverId();
 	protected static int sinkProcessId = 0;
-
+	
 	public Sinker() {
 		parMeta = Elasql.partitionMetaMgr();
 	}
@@ -76,10 +76,17 @@ public class Sinker {
 	}
 	
 	protected void generateReadingPlans(SunkPlan plan, TxNode node) {
+		boolean isTxDistributed = false;
+		
 		for (Edge e : node.getReadEdges()) {
 			long srcTxn = e.getTarget().getTxNum();
 			boolean isLocalResource = (e.getTarget().getPartId() == myId);
 			
+			if (!isLocalResource && !isTxDistributed) {
+				isTxDistributed = true;
+				plan.setDistributed(true);
+			}
+
 			if (plan.isHereMaster()) {
 				plan.addReadingInfo(e.getResourceKey(), srcTxn);
 				

--- a/src/main/java/org/elasql/schedule/tpart/sink/SunkPlan.java
+++ b/src/main/java/org/elasql/schedule/tpart/sink/SunkPlan.java
@@ -13,6 +13,7 @@ import org.elasql.sql.PrimaryKey;
 public class SunkPlan {
 	private int sinkProcessId;
 	private boolean isHereMaster;
+	private boolean isTxDistributed;
 
 	// key->srcTxNum
 	private Map<PrimaryKey, Long> readingInfoMap;
@@ -95,6 +96,14 @@ public class SunkPlan {
 
 	public boolean isHereMaster() {
 		return isHereMaster;
+	}
+	
+	public void setDistributed(boolean isTxDistributed) {
+		this.isTxDistributed = isTxDistributed;
+	}
+	
+	public boolean isTxDistributed() {
+		return isTxDistributed;
 	}
 
 	public void addLocalWriteBackInfo(PrimaryKey key) {


### PR DESCRIPTION
- Add `isTxDistributed` feature in the latency file