### PR TITLE
2021/12/08 - Merge Routine

### DIFF
--- a/src/main/java/org/elasql/perf/tpart/SpCallPreprocessor.java
+++ b/src/main/java/org/elasql/perf/tpart/SpCallPreprocessor.java
@@ -94,7 +94,8 @@ public class SpCallPreprocessor extends Task {
 				TPartStoredProcedureTask task = createSpTask(spc);
 				
 				// Add normal SPs to the task batch
-				if (task.getProcedureType() == ProcedureType.NORMAL) {
+				if (task.getProcedureType() == ProcedureType.NORMAL ||
+						task.getProcedureType() == ProcedureType.CONTROL) {
 					// Pre-process the transaction 
 					if (TPartPerformanceManager.ENABLE_COLLECTING_DATA ||
 							performanceEstimator != null) {
@@ -139,7 +140,8 @@ public class SpCallPreprocessor extends Task {
 		TransactionFeatures features = featureExtractor.extractFeatures(task, graph);
 		
 		// Record the feature if necessary
-		if (TPartPerformanceManager.ENABLE_COLLECTING_DATA) {
+		if (TPartPerformanceManager.ENABLE_COLLECTING_DATA &&
+				task.getProcedureType() != ProcedureType.CONTROL) {
 			featureRecorder.record(features);
 			dependencyRecorder.record(features);
 		}

--- a/src/main/java/org/elasql/perf/tpart/ai/ReadCountEstimator.java
+++ b/src/main/java/org/elasql/perf/tpart/ai/ReadCountEstimator.java
@@ -5,10 +5,28 @@ import org.elasql.storage.metadata.PartitionMetaMgr;
 
 public class ReadCountEstimator implements Estimator {
 	
-	private static double[] latency = new double[] {10, 7.423, 4.765};
+//	private static double[] latency = new double[] {10, 7.423, 4.765};
+//	private static int[] masterCpuTime = new int[] {60, 90, 120};
+//	private static int[] slaveCpuTime = new int[] {22, 52, 82};
 	
-	private static int[] masterCpuTime = new int[] {60, 90, 120};
-	private static int[] slaveCpuTime = new int[] {22, 52, 82};
+	private static final int MAX_READ = 24;
+	
+	// TPC-C
+	private static double[] latency;
+	private static int[] masterCpuTime;
+	private static int[] slaveCpuTime;
+	
+	static {
+		latency = new double[MAX_READ];
+		masterCpuTime = new int[MAX_READ];
+		slaveCpuTime = new int[MAX_READ];
+		
+		for (int i = 0; i < MAX_READ; i++) {
+			latency[MAX_READ - i - 1] = 50 + i * 5;
+			masterCpuTime[i] = 200 + i * 50;
+			slaveCpuTime[i] = 100 + i * 50;
+		}
+	}
 	
 	@Override
 	public TransactionEstimation estimate(TransactionFeatures features) {

--- a/src/main/java/org/elasql/perf/tpart/control/ControlParamUpdateProcedure.java
+++ b/src/main/java/org/elasql/perf/tpart/control/ControlParamUpdateProcedure.java
@@ -31,4 +31,9 @@ public class ControlParamUpdateProcedure extends TPartStoredProcedure<ControlPar
 	protected void executeSql(Map<PrimaryKey, CachedRecord> readings) {
 		// Do nothing
 	}
+	
+	@Override
+	public ProcedureType getProcedureType() {
+		return ProcedureType.CONTROL;
+	}
 }

--- a/src/main/java/org/elasql/perf/tpart/control/PidController.java
+++ b/src/main/java/org/elasql/perf/tpart/control/PidController.java
@@ -26,6 +26,9 @@ public class PidController {
 	private double previousError;
 	private double integral;
 	
+	// For debug
+	private String latestUpdateLog = "";
+	
 	public PidController(double initialParameter) {
 		this.initialParameter = initialParameter;
 		this.controlParameter = initialParameter;
@@ -43,7 +46,7 @@ public class PidController {
 		this.reference = reference;
 	}
 	
-	public String updateControlParameters(double timeOffsetInSecs) {
+	public void updateControlParameters(double timeOffsetInSecs) {
 		double error = reference - observation;
 		
 		// Calculate PID values
@@ -59,17 +62,19 @@ public class PidController {
 		controlParameter = initialParameter * Math.exp(-controlSignal);
 		
 		// For debugging
-		String updateInfo = String.format("[%f, %f, %f, %f, %f, %f, %f, %f]",
+		latestUpdateLog = String.format("[%f, %f, %f, %f, %f, %f, %f, %f]",
 				reference, observation, error, proportional, integral,
 				derivative, controlSignal, controlParameter);
 		
 		// Record the error
 		previousError = error;
-		
-		return updateInfo;
 	}
 	
 	public double getControlParameter() {
 		return controlParameter;
+	}
+	
+	public String getLatestUpdateLog() {
+		return latestUpdateLog;
 	}
 }

--- a/src/main/java/org/elasql/perf/tpart/control/PidController.java
+++ b/src/main/java/org/elasql/perf/tpart/control/PidController.java
@@ -43,7 +43,7 @@ public class PidController {
 		this.reference = reference;
 	}
 	
-	public void updateControlParameters(double timeOffsetInSecs) {
+	public String updateControlParameters(double timeOffsetInSecs) {
 		double error = reference - observation;
 		
 		// Calculate PID values
@@ -58,11 +58,15 @@ public class PidController {
 		// Update the parameter
 		controlParameter = initialParameter * Math.exp(-controlSignal);
 		
-		System.out.println(String.format("[%f, %f, %f, %f, %f, %f, %f, %f]",
-				reference, observation, error, proportional, integral, derivative, controlSignal, controlParameter));
+		// For debugging
+		String updateInfo = String.format("[%f, %f, %f, %f, %f, %f, %f, %f]",
+				reference, observation, error, proportional, integral,
+				derivative, controlSignal, controlParameter);
 		
 		// Record the error
 		previousError = error;
+		
+		return updateInfo;
 	}
 	
 	public double getControlParameter() {

--- a/src/main/java/org/elasql/perf/tpart/control/RoutingControlActuator.java
+++ b/src/main/java/org/elasql/perf/tpart/control/RoutingControlActuator.java
@@ -124,7 +124,6 @@ public class RoutingControlActuator extends Task {
 	
 	private void acquireObservations() {
 		// TODO: add disk and network I/O
-		// XXX: right observation?
 		for (int nodeId = 0; nodeId < PartitionMetaMgr.NUM_PARTITIONS; nodeId++) {
 			double observation = metricWarehouse.getAveragedSystemCpuLoad(nodeId, UPDATE_PERIOD);
 			observation = observation / CPU_MAX_CAPACITIES[nodeId];
@@ -142,13 +141,14 @@ public class RoutingControlActuator extends Task {
 		double average = sum / PartitionMetaMgr.NUM_PARTITIONS;
 		for (int nodeId = 0; nodeId < PartitionMetaMgr.NUM_PARTITIONS; nodeId++)
 			alpha[nodeId].setReference(average);
-//			alpha[nodeId].setReference(0.8);
 	}
 	
 	private void updateParameters(double timeOffsetInSecs) {
 		for (int nodeId = 0; nodeId < PartitionMetaMgr.NUM_PARTITIONS; nodeId++) {
-			String info = alpha[nodeId].updateControlParameters(timeOffsetInSecs);
-			System.out.println("Alpha #" + nodeId + ": " + info);
+			alpha[nodeId].updateControlParameters(timeOffsetInSecs);
+			
+			// Debug
+			System.out.println("Alpha #" + nodeId + ": " + alpha[nodeId].getLatestUpdateLog());
 		}
 	}
 	

--- a/src/main/java/org/elasql/perf/tpart/control/RoutingControlActuator.java
+++ b/src/main/java/org/elasql/perf/tpart/control/RoutingControlActuator.java
@@ -1,6 +1,5 @@
 package org.elasql.perf.tpart.control;
 
-import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -147,8 +146,8 @@ public class RoutingControlActuator extends Task {
 	
 	private void updateParameters(double timeOffsetInSecs) {
 		for (int nodeId = 0; nodeId < PartitionMetaMgr.NUM_PARTITIONS; nodeId++) {
-			System.out.print("Alaph #" + nodeId + ": ");
-			alpha[nodeId].updateControlParameters(timeOffsetInSecs);
+			String info = alpha[nodeId].updateControlParameters(timeOffsetInSecs);
+			System.out.print("Alpha #" + nodeId + ": " + info);
 		}
 	}
 	

--- a/src/main/java/org/elasql/perf/tpart/control/RoutingControlActuator.java
+++ b/src/main/java/org/elasql/perf/tpart/control/RoutingControlActuator.java
@@ -142,12 +142,13 @@ public class RoutingControlActuator extends Task {
 		double average = sum / PartitionMetaMgr.NUM_PARTITIONS;
 		for (int nodeId = 0; nodeId < PartitionMetaMgr.NUM_PARTITIONS; nodeId++)
 			alpha[nodeId].setReference(average);
+//			alpha[nodeId].setReference(0.8);
 	}
 	
 	private void updateParameters(double timeOffsetInSecs) {
 		for (int nodeId = 0; nodeId < PartitionMetaMgr.NUM_PARTITIONS; nodeId++) {
 			String info = alpha[nodeId].updateControlParameters(timeOffsetInSecs);
-			System.out.print("Alpha #" + nodeId + ": " + info);
+			System.out.println("Alpha #" + nodeId + ": " + info);
 		}
 	}
 	

--- a/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
@@ -4,7 +4,6 @@ import org.elasql.perf.tpart.TPartPerformanceManager;
 import org.elasql.server.Elasql;
 import org.vanilladb.core.server.task.Task;
 import org.vanilladb.core.storage.buffer.BufferPoolMonitor;
-import org.vanilladb.core.storage.tx.concurrency.LockTable;
 import org.vanilladb.core.util.TransactionProfiler;
 
 import oshi.SystemInfo;

--- a/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
@@ -4,6 +4,7 @@ import org.elasql.perf.tpart.TPartPerformanceManager;
 import org.elasql.server.Elasql;
 import org.vanilladb.core.server.task.Task;
 import org.vanilladb.core.storage.buffer.BufferPoolMonitor;
+import org.vanilladb.core.storage.tx.concurrency.LockTable;
 import org.vanilladb.core.util.TransactionProfiler;
 
 import oshi.SystemInfo;
@@ -19,7 +20,6 @@ import oshi.software.os.OperatingSystem;
  * @author Yu-Shan Lin
  */
 public class MetricCollector extends Task {
-
 	private static final int SYSTEM_METRIC_INTERVAL = 100; // in milliseconds
 
 	private TransactionMetricRecorder metricRecorder;
@@ -96,6 +96,7 @@ public class MetricCollector extends Task {
 		
 		builder.setBufferReadWaitCount(BufferPoolMonitor.getReadWaitCount());
 		builder.setBufferWriteWaitCount(BufferPoolMonitor.getWriteWaitCount());
+		builder.setBlockWaitDiff(BufferPoolMonitor.getBlockWaitDiff());
 		builder.setBlockWaitCount(BufferPoolMonitor.getBlockWaitCount());
 		
 		collectCpuLoad(builder);

--- a/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
@@ -96,7 +96,7 @@ public class MetricCollector extends Task {
 		
 		builder.setBufferReadWaitCount(BufferPoolMonitor.getReadWaitCount());
 		builder.setBufferWriteWaitCount(BufferPoolMonitor.getWriteWaitCount());
-		builder.setBlockWaitDiff(BufferPoolMonitor.getBlockWaitDiff());
+		builder.setBlockReleaseCount(BufferPoolMonitor.getBlockReleaseCount());
 		builder.setBlockWaitCount(BufferPoolMonitor.getBlockWaitCount());
 		
 		collectCpuLoad(builder);

--- a/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
@@ -4,6 +4,7 @@ import org.elasql.perf.tpart.TPartPerformanceManager;
 import org.elasql.server.Elasql;
 import org.vanilladb.core.server.task.Task;
 import org.vanilladb.core.storage.buffer.BufferPoolMonitor;
+import org.vanilladb.core.storage.record.RecordFile;
 import org.vanilladb.core.util.TransactionProfiler;
 
 import oshi.SystemInfo;
@@ -97,6 +98,8 @@ public class MetricCollector extends Task {
 		builder.setBufferWriteWaitCount(BufferPoolMonitor.getWriteWaitCount());
 		builder.setBlockReleaseCount(BufferPoolMonitor.getBlockReleaseCount());
 		builder.setBlockWaitCount(BufferPoolMonitor.getBlockWaitCount());
+		builder.setFhpReleaseCount(RecordFile.fhpReleaseCount());
+		builder.setFhpWaitCount(RecordFile.fhpWaitCount());
 		
 		collectCpuLoad(builder);
 		builder.setThreadActiveCount(getThreadActiveCount());

--- a/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
@@ -96,6 +96,7 @@ public class MetricCollector extends Task {
 		
 		builder.setBufferReadWaitCount(BufferPoolMonitor.getReadWaitCount());
 		builder.setBufferWriteWaitCount(BufferPoolMonitor.getWriteWaitCount());
+		builder.setBlockWaitCount(BufferPoolMonitor.getBlockWaitCount());
 		
 		collectCpuLoad(builder);
 		builder.setThreadActiveCount(getThreadActiveCount());

--- a/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
@@ -101,6 +101,8 @@ public class MetricCollector extends Task {
 		builder.setBlockWaitCount(BufferPoolMonitor.getBlockWaitCount());
 		builder.setFhpReleaseCount(RecordFile.fhpReleaseCount());
 		builder.setFhpWaitCount(RecordFile.fhpWaitCount());
+		builder.setPageGetValReleaseCount(Buffer.getPageGetValWaitCount());
+		builder.setPageSetValReleaseCount(Buffer.getPageSetValWaitCount());
 		builder.setPageGetValReleaseCount(Buffer.getPageGetValReleaseCount());
 		builder.setPageSetValReleaseCount(Buffer.getPageSetValReleaseCount());
 		

--- a/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/MetricCollector.java
@@ -3,6 +3,7 @@ package org.elasql.perf.tpart.metric;
 import org.elasql.perf.tpart.TPartPerformanceManager;
 import org.elasql.server.Elasql;
 import org.vanilladb.core.server.task.Task;
+import org.vanilladb.core.storage.buffer.Buffer;
 import org.vanilladb.core.storage.buffer.BufferPoolMonitor;
 import org.vanilladb.core.storage.record.RecordFile;
 import org.vanilladb.core.util.TransactionProfiler;
@@ -100,6 +101,8 @@ public class MetricCollector extends Task {
 		builder.setBlockWaitCount(BufferPoolMonitor.getBlockWaitCount());
 		builder.setFhpReleaseCount(RecordFile.fhpReleaseCount());
 		builder.setFhpWaitCount(RecordFile.fhpWaitCount());
+		builder.setPageGetValReleaseCount(Buffer.getPageGetValReleaseCount());
+		builder.setPageSetValReleaseCount(Buffer.getPageSetValReleaseCount());
 		
 		collectCpuLoad(builder);
 		builder.setThreadActiveCount(getThreadActiveCount());

--- a/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
@@ -20,6 +20,8 @@ public class TPartSystemMetrics implements MetricReport {
 		private int blockWaitCount;
 		private int fhpReleaseCount;
 		private int fhpWaitCount;
+		private int pageGetValReleaseCount;
+		private int pageSetValReleaseCount;
 		
 		// CPU Usage and Load
 		private long[] systemCpuLoadTicks;
@@ -76,6 +78,14 @@ public class TPartSystemMetrics implements MetricReport {
 			this.fhpWaitCount = fhpWaitCount;
 		}
 		
+		public void setPageGetValReleaseCount(int pageGetValReleaseCount) {
+			this.pageGetValReleaseCount = pageGetValReleaseCount;
+		}
+		
+		public void setPageSetValReleaseCount(int pageSetValReleaseCount) {
+			this.pageSetValReleaseCount = pageSetValReleaseCount;
+		}
+		
 		public void setSystemCpuLoadTicks(long[] systemCpuLoadTicks) {
 			this.systemCpuLoadTicks = systemCpuLoadTicks;
 		}
@@ -126,6 +136,8 @@ public class TPartSystemMetrics implements MetricReport {
 			metrics.blockWaitCount = blockWaitCount;
 			metrics.fhpReleaseCount = fhpReleaseCount;
 			metrics.fhpWaitCount = fhpWaitCount;
+			metrics.pageGetValReleaseCount = pageGetValReleaseCount;
+			metrics.pageSetValReleaseCount = pageSetValReleaseCount;
 			
 			metrics.systemCpuLoadTicks = systemCpuLoadTicks;
 			metrics.systemLoadAverage = systemLoadAverage;
@@ -155,6 +167,8 @@ public class TPartSystemMetrics implements MetricReport {
 	private int blockWaitCount;
 	private int fhpReleaseCount;
 	private int fhpWaitCount;
+	private int pageGetValReleaseCount;
+	private int pageSetValReleaseCount;
 	
 	// CPU Usage and Loading
 	private long[] systemCpuLoadTicks;
@@ -211,6 +225,14 @@ public class TPartSystemMetrics implements MetricReport {
 	
 	public int getFhpWaitCount() {
 		return fhpWaitCount;
+	}
+	
+	public int getPageGetValReleaseCount() {
+		return pageGetValReleaseCount;
+	}
+	
+	public int getPageSetValReleaseCount() {
+		return pageSetValReleaseCount;
 	}
 	
 	public long[] getSystemCpuLoadTicks() {

--- a/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
@@ -16,7 +16,7 @@ public class TPartSystemMetrics implements MetricReport {
 		
 		private int bufferReadWaitCount;
 		private int bufferWriteWaitCount;
-		private int blockWaitDiff;
+		private int blockReleaseCount;
 		private int blockWaitCount;
 		
 		// CPU Usage and Load
@@ -58,8 +58,8 @@ public class TPartSystemMetrics implements MetricReport {
 			this.bufferWriteWaitCount = bufferWriteWaitCount;
 		}
 		
-		public void setBlockWaitDiff(int blockWaitDiff) {
-			this.blockWaitDiff = blockWaitDiff;
+		public void setBlockReleaseCount(int blockReleaseCount) {
+			this.blockReleaseCount = blockReleaseCount;
 		}
 		
 		public void setBlockWaitCount(int blockWaitCount) {
@@ -112,7 +112,7 @@ public class TPartSystemMetrics implements MetricReport {
 			
 			metrics.bufferReadWaitCount = bufferReadWaitCount;
 			metrics.bufferWriteWaitCount = bufferWriteWaitCount;
-			metrics.blockWaitDiff = blockWaitDiff;
+			metrics.blockReleaseCount = blockReleaseCount;
 			metrics.blockWaitCount = blockWaitCount;
 			
 			metrics.systemCpuLoadTicks = systemCpuLoadTicks;
@@ -139,7 +139,7 @@ public class TPartSystemMetrics implements MetricReport {
 	
 	private int bufferReadWaitCount;
 	private int bufferWriteWaitCount;
-	private int blockWaitDiff;
+	private int blockReleaseCount;
 	private int blockWaitCount;
 	
 	// CPU Usage and Loading
@@ -183,8 +183,8 @@ public class TPartSystemMetrics implements MetricReport {
 		return bufferWriteWaitCount;
 	}
 	
-	public int getBlockWaitDiff() {
-		return blockWaitDiff;
+	public int getBlockReleaseCount() {
+		return blockReleaseCount;
 	}
 	
 	public int getBlockWaitCount() {

--- a/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
@@ -18,6 +18,8 @@ public class TPartSystemMetrics implements MetricReport {
 		private int bufferWriteWaitCount;
 		private int blockReleaseCount;
 		private int blockWaitCount;
+		private int fhpReleaseCount;
+		private int fhpWaitCount;
 		
 		// CPU Usage and Load
 		private long[] systemCpuLoadTicks;
@@ -64,6 +66,14 @@ public class TPartSystemMetrics implements MetricReport {
 		
 		public void setBlockWaitCount(int blockWaitCount) {
 			this.blockWaitCount = blockWaitCount;
+		}
+		
+		public void setFhpReleaseCount(int fhpReleaseCount) {
+			this.fhpReleaseCount = fhpReleaseCount;
+		}
+		
+		public void setFhpWaitCount(int fhpWaitCount) {
+			this.fhpWaitCount = fhpWaitCount;
 		}
 		
 		public void setSystemCpuLoadTicks(long[] systemCpuLoadTicks) {
@@ -114,6 +124,8 @@ public class TPartSystemMetrics implements MetricReport {
 			metrics.bufferWriteWaitCount = bufferWriteWaitCount;
 			metrics.blockReleaseCount = blockReleaseCount;
 			metrics.blockWaitCount = blockWaitCount;
+			metrics.fhpReleaseCount = fhpReleaseCount;
+			metrics.fhpWaitCount = fhpWaitCount;
 			
 			metrics.systemCpuLoadTicks = systemCpuLoadTicks;
 			metrics.systemLoadAverage = systemLoadAverage;
@@ -141,6 +153,8 @@ public class TPartSystemMetrics implements MetricReport {
 	private int bufferWriteWaitCount;
 	private int blockReleaseCount;
 	private int blockWaitCount;
+	private int fhpReleaseCount;
+	private int fhpWaitCount;
 	
 	// CPU Usage and Loading
 	private long[] systemCpuLoadTicks;
@@ -189,6 +203,14 @@ public class TPartSystemMetrics implements MetricReport {
 	
 	public int getBlockWaitCount() {
 		return blockWaitCount;
+	}
+	
+	public int getFhpReleaseCount() {
+		return fhpReleaseCount;
+	}
+	
+	public int getFhpWaitCount() {
+		return fhpWaitCount;
 	}
 	
 	public long[] getSystemCpuLoadTicks() {

--- a/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
@@ -16,6 +16,7 @@ public class TPartSystemMetrics implements MetricReport {
 		
 		private int bufferReadWaitCount;
 		private int bufferWriteWaitCount;
+		private int blockWaitCount;
 		
 		// CPU Usage and Load
 		private long[] systemCpuLoadTicks;
@@ -54,6 +55,10 @@ public class TPartSystemMetrics implements MetricReport {
 		
 		public void setBufferWriteWaitCount(int bufferWriteWaitCount) {
 			this.bufferWriteWaitCount = bufferWriteWaitCount;
+		}
+		
+		public void setBlockWaitCount(int blockWaitCount) {
+			this.blockWaitCount = blockWaitCount;
 		}
 		
 		public void setSystemCpuLoadTicks(long[] systemCpuLoadTicks) {
@@ -102,6 +107,7 @@ public class TPartSystemMetrics implements MetricReport {
 			
 			metrics.bufferReadWaitCount = bufferReadWaitCount;
 			metrics.bufferWriteWaitCount = bufferWriteWaitCount;
+			metrics.blockWaitCount = blockWaitCount;
 			
 			metrics.systemCpuLoadTicks = systemCpuLoadTicks;
 			metrics.systemLoadAverage = systemLoadAverage;
@@ -127,6 +133,7 @@ public class TPartSystemMetrics implements MetricReport {
 	
 	private int bufferReadWaitCount;
 	private int bufferWriteWaitCount;
+	private int blockWaitCount;
 	
 	// CPU Usage and Loading
 	private long[] systemCpuLoadTicks;
@@ -167,6 +174,10 @@ public class TPartSystemMetrics implements MetricReport {
 	
 	public int getBufferWriteWaitCount() {
 		return bufferWriteWaitCount;
+	}
+	
+	public int getBlockWaitCount() {
+		return blockWaitCount;
 	}
 	
 	public long[] getSystemCpuLoadTicks() {

--- a/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
@@ -16,6 +16,7 @@ public class TPartSystemMetrics implements MetricReport {
 		
 		private int bufferReadWaitCount;
 		private int bufferWriteWaitCount;
+		private int blockWaitDiff;
 		private int blockWaitCount;
 		
 		// CPU Usage and Load
@@ -55,6 +56,10 @@ public class TPartSystemMetrics implements MetricReport {
 		
 		public void setBufferWriteWaitCount(int bufferWriteWaitCount) {
 			this.bufferWriteWaitCount = bufferWriteWaitCount;
+		}
+		
+		public void setBlockWaitDiff(int blockWaitDiff) {
+			this.blockWaitDiff = blockWaitDiff;
 		}
 		
 		public void setBlockWaitCount(int blockWaitCount) {
@@ -107,6 +112,7 @@ public class TPartSystemMetrics implements MetricReport {
 			
 			metrics.bufferReadWaitCount = bufferReadWaitCount;
 			metrics.bufferWriteWaitCount = bufferWriteWaitCount;
+			metrics.blockWaitDiff = blockWaitDiff;
 			metrics.blockWaitCount = blockWaitCount;
 			
 			metrics.systemCpuLoadTicks = systemCpuLoadTicks;
@@ -133,6 +139,7 @@ public class TPartSystemMetrics implements MetricReport {
 	
 	private int bufferReadWaitCount;
 	private int bufferWriteWaitCount;
+	private int blockWaitDiff;
 	private int blockWaitCount;
 	
 	// CPU Usage and Loading
@@ -174,6 +181,10 @@ public class TPartSystemMetrics implements MetricReport {
 	
 	public int getBufferWriteWaitCount() {
 		return bufferWriteWaitCount;
+	}
+	
+	public int getBlockWaitDiff() {
+		return blockWaitDiff;
 	}
 	
 	public int getBlockWaitCount() {

--- a/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TPartSystemMetrics.java
@@ -20,6 +20,8 @@ public class TPartSystemMetrics implements MetricReport {
 		private int blockWaitCount;
 		private int fhpReleaseCount;
 		private int fhpWaitCount;
+		private int pageGetValWaitCount;
+		private int pageSetValWaitCount;
 		private int pageGetValReleaseCount;
 		private int pageSetValReleaseCount;
 		
@@ -76,6 +78,14 @@ public class TPartSystemMetrics implements MetricReport {
 		
 		public void setFhpWaitCount(int fhpWaitCount) {
 			this.fhpWaitCount = fhpWaitCount;
+		}
+		
+		public void setPageGetValWaitCount(int pageGetValWaitCount) {
+			this.pageGetValWaitCount = pageGetValWaitCount;
+		}
+		
+		public void setPageSetValWaitCount(int pageSetValWaitCount) {
+			this.pageSetValWaitCount = pageSetValWaitCount;
 		}
 		
 		public void setPageGetValReleaseCount(int pageGetValReleaseCount) {
@@ -136,6 +146,8 @@ public class TPartSystemMetrics implements MetricReport {
 			metrics.blockWaitCount = blockWaitCount;
 			metrics.fhpReleaseCount = fhpReleaseCount;
 			metrics.fhpWaitCount = fhpWaitCount;
+			metrics.pageGetValWaitCount = pageGetValWaitCount;
+			metrics.pageSetValWaitCount = pageSetValWaitCount;
 			metrics.pageGetValReleaseCount = pageGetValReleaseCount;
 			metrics.pageSetValReleaseCount = pageSetValReleaseCount;
 			
@@ -167,6 +179,8 @@ public class TPartSystemMetrics implements MetricReport {
 	private int blockWaitCount;
 	private int fhpReleaseCount;
 	private int fhpWaitCount;
+	private int pageGetValWaitCount;
+	private int pageSetValWaitCount;
 	private int pageGetValReleaseCount;
 	private int pageSetValReleaseCount;
 	
@@ -225,6 +239,14 @@ public class TPartSystemMetrics implements MetricReport {
 	
 	public int getFhpWaitCount() {
 		return fhpWaitCount;
+	}
+	
+	public int getPageGetValWaitCount() {
+		return pageGetValWaitCount;
+	}
+	
+	public int getPageSetValWaitCount() {
+		return pageSetValWaitCount;
 	}
 	
 	public int getPageGetValReleaseCount() {

--- a/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
@@ -120,12 +120,12 @@ public class TpartMetricWarehouse extends Task implements MetricWarehouse {
 		}
 	}
 	
-	public synchronized int getBlockWaitDiff(int serverId) {
+	public synchronized int getBlockReleaseCount(int serverId) {
 		List<StampedMetric> history = metricStore.get(serverId);
 		if (history.isEmpty()) {
 			return 0;
 		} else {
-			return history.get(history.size() - 1).metric.getBlockWaitDiff();
+			return history.get(history.size() - 1).metric.getBlockReleaseCount();
 		}
 	}
 	

--- a/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
@@ -156,6 +156,24 @@ public class TpartMetricWarehouse extends Task implements MetricWarehouse {
 		}
 	}
 	
+	public synchronized int getPageGetValWaitCount(int serverId) {
+		List<StampedMetric> history = metricStore.get(serverId);
+		if (history.isEmpty()) {
+			return 0;
+		} else {
+			return history.get(history.size() - 1).metric.getPageGetValWaitCount();
+		}
+	}
+	
+	public synchronized int getPageSetValWaitCount(int serverId) {
+		List<StampedMetric> history = metricStore.get(serverId);
+		if (history.isEmpty()) {
+			return 0;
+		} else {
+			return history.get(history.size() - 1).metric.getPageSetValWaitCount();
+		}
+	}
+	
 	public synchronized int getPageGetValReleaseCount(int serverId) {
 		List<StampedMetric> history = metricStore.get(serverId);
 		if (history.isEmpty()) {

--- a/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
@@ -156,6 +156,24 @@ public class TpartMetricWarehouse extends Task implements MetricWarehouse {
 		}
 	}
 	
+	public synchronized int getPageGetValReleaseCount(int serverId) {
+		List<StampedMetric> history = metricStore.get(serverId);
+		if (history.isEmpty()) {
+			return 0;
+		} else {
+			return history.get(history.size() - 1).metric.getPageGetValReleaseCount();
+		}
+	}
+	
+	public synchronized int getPageSetValReleaseCount(int serverId) {
+		List<StampedMetric> history = metricStore.get(serverId);
+		if (history.isEmpty()) {
+			return 0;
+		} else {
+			return history.get(history.size() - 1).metric.getPageSetValReleaseCount();
+		}
+	}
+	
 	public synchronized double getProcessCpuLoad(int serverId) {
 		List<StampedMetric> history = metricStore.get(serverId);
 		if (history.size() < 2) {

--- a/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
@@ -138,6 +138,24 @@ public class TpartMetricWarehouse extends Task implements MetricWarehouse {
 		}
 	}
 	
+	public synchronized int getFhpReleaseCount(int serverId) {
+		List<StampedMetric> history = metricStore.get(serverId);
+		if (history.isEmpty()) {
+			return 0;
+		} else {
+			return history.get(history.size() - 1).metric.getFhpReleaseCount();
+		}
+	}
+	
+	public synchronized int getFhpWaitCount(int serverId) {
+		List<StampedMetric> history = metricStore.get(serverId);
+		if (history.isEmpty()) {
+			return 0;
+		} else {
+			return history.get(history.size() - 1).metric.getFhpWaitCount();
+		}
+	}
+	
 	public synchronized double getProcessCpuLoad(int serverId) {
 		List<StampedMetric> history = metricStore.get(serverId);
 		if (history.size() < 2) {

--- a/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
@@ -120,6 +120,15 @@ public class TpartMetricWarehouse extends Task implements MetricWarehouse {
 		}
 	}
 	
+	public synchronized int getBlockWaitCount(int serverId) {
+		List<StampedMetric> history = metricStore.get(serverId);
+		if (history.isEmpty()) {
+			return 0;
+		} else {
+			return history.get(history.size() - 1).metric.getBlockWaitCount();
+		}
+	}
+	
 	public synchronized double getProcessCpuLoad(int serverId) {
 		List<StampedMetric> history = metricStore.get(serverId);
 		if (history.size() < 2) {

--- a/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
+++ b/src/main/java/org/elasql/perf/tpart/metric/TpartMetricWarehouse.java
@@ -120,6 +120,15 @@ public class TpartMetricWarehouse extends Task implements MetricWarehouse {
 		}
 	}
 	
+	public synchronized int getBlockWaitDiff(int serverId) {
+		List<StampedMetric> history = metricStore.get(serverId);
+		if (history.isEmpty()) {
+			return 0;
+		} else {
+			return history.get(history.size() - 1).metric.getBlockWaitDiff();
+		}
+	}
+	
 	public synchronized int getBlockWaitCount(int serverId) {
 		List<StampedMetric> history = metricStore.get(serverId);
 		if (history.isEmpty()) {

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -75,6 +75,8 @@ public class FeatureExtractor {
 		builder.addFeature("Block Lock Wait Count", extractBlockLockWaitCount());
 		builder.addFeature("File Header Page Release Count", extractFhpReleaseCount());
 		builder.addFeature("File Header Page Wait Count", extractFhpWaitCount());
+		builder.addFeature("Page GetVal Release Count", extractPageGetValReleaseCount());
+		builder.addFeature("Page SetVal Release Count", extractPageSetValReleaseCount());
 
 		// Features below are from the servers
 		builder.addFeature("System CPU Load", extractSystemCpuLoad());
@@ -184,6 +186,26 @@ public class FeatureExtractor {
 			fhpWaitCounts[serverId] = metricWarehouse.getFhpWaitCount(serverId);
 		
 		return fhpWaitCounts;
+	}
+	
+	private Integer[] extractPageGetValReleaseCount() {
+		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
+		Integer[] pageGetValReleaseCounts = new Integer[serverCount];
+		
+		for (int serverId = 0; serverId < serverCount; serverId++)	
+			pageGetValReleaseCounts[serverId] = metricWarehouse.getPageGetValReleaseCount(serverId);
+		
+		return pageGetValReleaseCounts;
+	}
+	
+	private Integer[] extractPageSetValReleaseCount() {
+		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
+		Integer[] pageSetValReleaseCounts = new Integer[serverCount];
+		
+		for (int serverId = 0; serverId < serverCount; serverId++)	
+			pageSetValReleaseCounts[serverId] = metricWarehouse.getPageSetValReleaseCount(serverId);
+		
+		return pageSetValReleaseCounts;
 	}
 	
 	private Double[] extractSystemCpuLoad() {

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -71,7 +71,7 @@ public class FeatureExtractor {
 		
 		builder.addFeature("Buffer RL Wait Count", extractBufferReadWaitCount());
 		builder.addFeature("Buffer WL Wait Count", extractBufferWriteWaitCount());
-		builder.addFeature("Block Lock Wait Diff", extractBlockLockWaitDiff());
+		builder.addFeature("Block Lock Release Count", extractBlockLockReleaseCount());
 		builder.addFeature("Block Lock Wait Count", extractBlockLockWaitCount());
 
 		// Features below are from the servers
@@ -144,12 +144,12 @@ public class FeatureExtractor {
 		return bufferWaitCounts;
 	}
 	
-	private Integer[] extractBlockLockWaitDiff() {
+	private Integer[] extractBlockLockReleaseCount() {
 		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
 		Integer[] blockWaitDiffs = new Integer[serverCount];
 		
 		for (int serverId = 0; serverId < serverCount; serverId++)	
-			blockWaitDiffs[serverId] = metricWarehouse.getBlockWaitDiff(serverId);
+			blockWaitDiffs[serverId] = metricWarehouse.getBlockReleaseCount(serverId);
 		
 		return blockWaitDiffs;
 	}

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -75,6 +75,8 @@ public class FeatureExtractor {
 		builder.addFeature("Block Lock Wait Count", extractBlockLockWaitCount());
 		builder.addFeature("File Header Page Release Count", extractFhpReleaseCount());
 		builder.addFeature("File Header Page Wait Count", extractFhpWaitCount());
+		builder.addFeature("Page GetVal Wait Count", extractPageGetValWaitCount());
+		builder.addFeature("Page SetVal Wait Count", extractPageSetValWaitCount());
 		builder.addFeature("Page GetVal Release Count", extractPageGetValReleaseCount());
 		builder.addFeature("Page SetVal Release Count", extractPageSetValReleaseCount());
 
@@ -186,6 +188,26 @@ public class FeatureExtractor {
 			fhpWaitCounts[serverId] = metricWarehouse.getFhpWaitCount(serverId);
 		
 		return fhpWaitCounts;
+	}
+	
+	private Integer[] extractPageGetValWaitCount() {
+		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
+		Integer[] pageGetValWaitCounts = new Integer[serverCount];
+		
+		for (int serverId = 0; serverId < serverCount; serverId++)	
+			pageGetValWaitCounts[serverId] = metricWarehouse.getPageGetValWaitCount(serverId);
+		
+		return pageGetValWaitCounts;
+	}
+	
+	private Integer[] extractPageSetValWaitCount() {
+		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
+		Integer[] pageSetValWaitCounts = new Integer[serverCount];
+		
+		for (int serverId = 0; serverId < serverCount; serverId++)	
+			pageSetValWaitCounts[serverId] = metricWarehouse.getPageSetValWaitCount(serverId);
+		
+		return pageSetValWaitCounts;
 	}
 	
 	private Integer[] extractPageGetValReleaseCount() {

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -73,6 +73,8 @@ public class FeatureExtractor {
 		builder.addFeature("Buffer WL Wait Count", extractBufferWriteWaitCount());
 		builder.addFeature("Block Lock Release Count", extractBlockLockReleaseCount());
 		builder.addFeature("Block Lock Wait Count", extractBlockLockWaitCount());
+		builder.addFeature("File Header Page Release Count", extractFhpReleaseCount());
+		builder.addFeature("File Header Page Wait Count", extractFhpWaitCount());
 
 		// Features below are from the servers
 		builder.addFeature("System CPU Load", extractSystemCpuLoad());
@@ -162,6 +164,26 @@ public class FeatureExtractor {
 			blockWaitCounts[serverId] = metricWarehouse.getBlockWaitCount(serverId);
 		
 		return blockWaitCounts;
+	}
+	
+	private Integer[] extractFhpReleaseCount() {
+		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
+		Integer[] fhpReleaseCounts = new Integer[serverCount];
+		
+		for (int serverId = 0; serverId < serverCount; serverId++)	
+			fhpReleaseCounts[serverId] = metricWarehouse.getFhpReleaseCount(serverId);
+		
+		return fhpReleaseCounts;
+	}
+	
+	private Integer[] extractFhpWaitCount() {
+		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
+		Integer[] fhpWaitCounts = new Integer[serverCount];
+		
+		for (int serverId = 0; serverId < serverCount; serverId++)	
+			fhpWaitCounts[serverId] = metricWarehouse.getFhpWaitCount(serverId);
+		
+		return fhpWaitCounts;
 	}
 	
 	private Double[] extractSystemCpuLoad() {

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -71,6 +71,7 @@ public class FeatureExtractor {
 		
 		builder.addFeature("Buffer RL Wait Count", extractBufferReadWaitCount());
 		builder.addFeature("Buffer WL Wait Count", extractBufferWriteWaitCount());
+		builder.addFeature("Block Lock Wait Diff", extractBlockLockWaitDiff());
 		builder.addFeature("Block Lock Wait Count", extractBlockLockWaitCount());
 
 		// Features below are from the servers
@@ -141,6 +142,16 @@ public class FeatureExtractor {
 			bufferWaitCounts[serverId] = metricWarehouse.getBufferWriteWaitCount(serverId);
 		
 		return bufferWaitCounts;
+	}
+	
+	private Integer[] extractBlockLockWaitDiff() {
+		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
+		Integer[] blockWaitDiffs = new Integer[serverCount];
+		
+		for (int serverId = 0; serverId < serverCount; serverId++)	
+			blockWaitDiffs[serverId] = metricWarehouse.getBlockWaitDiff(serverId);
+		
+		return blockWaitDiffs;
 	}
 	
 	private Integer[] extractBlockLockWaitCount() {

--- a/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/FeatureExtractor.java
@@ -71,6 +71,7 @@ public class FeatureExtractor {
 		
 		builder.addFeature("Buffer RL Wait Count", extractBufferReadWaitCount());
 		builder.addFeature("Buffer WL Wait Count", extractBufferWriteWaitCount());
+		builder.addFeature("Block Lock Wait Count", extractBlockLockWaitCount());
 
 		// Features below are from the servers
 		builder.addFeature("System CPU Load", extractSystemCpuLoad());
@@ -140,6 +141,16 @@ public class FeatureExtractor {
 			bufferWaitCounts[serverId] = metricWarehouse.getBufferWriteWaitCount(serverId);
 		
 		return bufferWaitCounts;
+	}
+	
+	private Integer[] extractBlockLockWaitCount() {
+		int serverCount = PartitionMetaMgr.NUM_PARTITIONS;
+		Integer[] blockWaitCounts = new Integer[serverCount];
+		
+		for (int serverId = 0; serverId < serverCount; serverId++)	
+			blockWaitCounts[serverId] = metricWarehouse.getBlockWaitCount(serverId);
+		
+		return blockWaitCounts;
 	}
 	
 	private Double[] extractSystemCpuLoad() {

--- a/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
@@ -46,8 +46,10 @@ public class TransactionFeatures {
 		
 		featureKeys.add("Buffer RL Wait Count");
 		featureKeys.add("Buffer WL Wait Count");
-		featureKeys.add("Block Lock Wait Diff");
+		featureKeys.add("Block Lock Release Count");
 		featureKeys.add("Block Lock Wait Count");
+		featureKeys.add("File Header Page Release Count");
+		featureKeys.add("File Header Page Wait Count");
 		
 		featureKeys.add("System CPU Load");
 		featureKeys.add("Process CPU Load");

--- a/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
@@ -50,6 +50,8 @@ public class TransactionFeatures {
 		featureKeys.add("Block Lock Wait Count");
 		featureKeys.add("File Header Page Release Count");
 		featureKeys.add("File Header Page Wait Count");
+		featureKeys.add("Page GetVal Wait Count");
+		featureKeys.add("Page SetVal Wait Count");
 		featureKeys.add("Page GetVal Release Count");
 		featureKeys.add("Page SetVal Release Count");
 		

--- a/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
@@ -46,6 +46,7 @@ public class TransactionFeatures {
 		
 		featureKeys.add("Buffer RL Wait Count");
 		featureKeys.add("Buffer WL Wait Count");
+		featureKeys.add("Block Lock Wait Diff");
 		featureKeys.add("Block Lock Wait Count");
 		
 		featureKeys.add("System CPU Load");

--- a/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
@@ -50,6 +50,8 @@ public class TransactionFeatures {
 		featureKeys.add("Block Lock Wait Count");
 		featureKeys.add("File Header Page Release Count");
 		featureKeys.add("File Header Page Wait Count");
+		featureKeys.add("Page GetVal Release Count");
+		featureKeys.add("Page SetVal Release Count");
 		
 		featureKeys.add("System CPU Load");
 		featureKeys.add("Process CPU Load");

--- a/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
+++ b/src/main/java/org/elasql/perf/tpart/workload/TransactionFeatures.java
@@ -46,6 +46,7 @@ public class TransactionFeatures {
 		
 		featureKeys.add("Buffer RL Wait Count");
 		featureKeys.add("Buffer WL Wait Count");
+		featureKeys.add("Block Lock Wait Count");
 		
 		featureKeys.add("System CPU Load");
 		featureKeys.add("Process CPU Load");

--- a/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedure.java
+++ b/src/main/java/org/elasql/procedure/tpart/TPartStoredProcedure.java
@@ -31,7 +31,7 @@ public abstract class TPartStoredProcedure<H extends StoredProcedureParamHelper>
 		extends StoredProcedure<H> {
 	
 	public static enum ProcedureType {
-		NOP, NORMAL, UTILITY, MIGRATION
+		NOP, NORMAL, UTILITY, MIGRATION, CONTROL
 	}
 
 	// Protected resource

--- a/src/main/java/org/elasql/schedule/tpart/TPartScheduler.java
+++ b/src/main/java/org/elasql/schedule/tpart/TPartScheduler.java
@@ -108,7 +108,8 @@ public class TPartScheduler extends Task implements Scheduler {
 //					continue;
 //				}
 
-				if (task.getProcedureType() == ProcedureType.NORMAL) {
+				if (task.getProcedureType() == ProcedureType.NORMAL ||
+						task.getProcedureType() == ProcedureType.CONTROL) {
 					batchedTasks.add(task);
 				}
 				

--- a/src/main/java/org/elasql/schedule/tpart/control/ControlBasedRouter.java
+++ b/src/main/java/org/elasql/schedule/tpart/control/ControlBasedRouter.java
@@ -12,7 +12,6 @@ import org.elasql.perf.tpart.control.ControlParamUpdateProcedure;
 import org.elasql.procedure.tpart.TPartStoredProcedureTask;
 import org.elasql.schedule.tpart.BatchNodeInserter;
 import org.elasql.schedule.tpart.graph.TGraph;
-import org.elasql.sql.PrimaryKey;
 import org.elasql.storage.metadata.PartitionMetaMgr;
 
 public class ControlBasedRouter implements BatchNodeInserter {
@@ -99,8 +98,8 @@ public class ControlBasedRouter implements BatchNodeInserter {
 		}
 		
 		// Debug
-		if (isPartition0Tx(task))
-			assignedCounts[bestMasterId]++;
+//		if (isPartition0Tx(task))
+		assignedCounts[bestMasterId]++;
 		
 		graph.insertTxNode(task, bestMasterId);
 	}
@@ -114,21 +113,21 @@ public class ControlBasedRouter implements BatchNodeInserter {
 		return e - paramAlpha[masterId] * cpuFactor;
 	}
 	
-	private boolean isPartition0Tx(TPartStoredProcedureTask task) {
-		// Find the warehouse record and check w_id
-		for (PrimaryKey key : task.getReadSet()) {
-			if (key.getTableName().equals("warehouse")) {
-				int wid = (Integer) key.getVal("w_id").asJavaVal();
-				if (wid <= 10) {
-					return true;
-				} else {
-					return false;
-				}
-			}
-		}
-		
-		throw new RuntimeException("Something wrong");
-	}
+//	private boolean isPartition0Tx(TPartStoredProcedureTask task) {
+//		// Find the warehouse record and check w_id
+//		for (PrimaryKey key : task.getReadSet()) {
+//			if (key.getTableName().equals("warehouse")) {
+//				int wid = (Integer) key.getVal("w_id").asJavaVal();
+//				if (wid <= 10) {
+//					return true;
+//				} else {
+//					return false;
+//				}
+//			}
+//		}
+//		
+//		throw new RuntimeException("Something wrong");
+//	}
 
 	// Debug: show the distribution of assigned masters
 	private void reportRoutingDistribution(long currentTime) {

--- a/src/main/java/org/elasql/schedule/tpart/control/ControlBasedRouter.java
+++ b/src/main/java/org/elasql/schedule/tpart/control/ControlBasedRouter.java
@@ -46,7 +46,7 @@ public class ControlBasedRouter implements BatchNodeInserter {
 			if (task.getProcedure().getClass().equals(ControlParamUpdateProcedure.class)) {
 				ControlParamUpdateProcedure procedure = 
 						(ControlParamUpdateProcedure) task.getProcedure();
-//				updateParameters(procedure.getParamHelper());
+				updateParameters(procedure.getParamHelper());
 			} else {
 				insert(graph, task);
 

--- a/src/main/java/org/elasql/schedule/tpart/control/HotAvoidanceRouter.java
+++ b/src/main/java/org/elasql/schedule/tpart/control/HotAvoidanceRouter.java
@@ -1,0 +1,89 @@
+package org.elasql.schedule.tpart.control;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.elasql.procedure.tpart.TPartStoredProcedureTask;
+import org.elasql.schedule.tpart.BatchNodeInserter;
+import org.elasql.schedule.tpart.graph.TGraph;
+import org.elasql.server.Elasql;
+import org.elasql.sql.PrimaryKey;
+import org.elasql.storage.metadata.PartitionMetaMgr;
+
+public class HotAvoidanceRouter implements BatchNodeInserter {
+	
+	private static final int PART_TO_AVOID = 0;
+	
+	private PartitionMetaMgr partMgr = Elasql.partitionMetaMgr();
+
+	@Override
+	public void insertBatch(TGraph graph, List<TPartStoredProcedureTask> tasks) {
+		for (TPartStoredProcedureTask task : tasks) {
+			insert(graph, task);
+		}
+	}
+	
+	private void insert(TGraph graph, TPartStoredProcedureTask task) {
+		int destination = findBestDestination(graph, task);
+		
+		// Debug
+		if (task.getTxNum() % 5000 == 0) {
+			System.out.println("Final: " + destination);
+		}
+		
+		graph.insertTxNode(task, destination);
+	}
+	
+	private int findBestDestination(TGraph graph, TPartStoredProcedureTask task) {
+		int[] readDistribution = new int[PartitionMetaMgr.NUM_PARTITIONS];
+		
+		// Count reads from each partition
+		for (PrimaryKey key : task.getReadSet()) {
+			// Skip replicated records
+			if (partMgr.isFullyReplicated(key))
+				continue;
+			
+			int partId = graph.getResourcePosition(key).getPartId();
+			readDistribution[partId]++;
+		}
+		
+		// Find the partition that has the most reads
+		int mostReadPartId = 0;
+		for (int partId = 1; partId < PartitionMetaMgr.NUM_PARTITIONS; partId++) {
+			if (readDistribution[partId] > readDistribution[mostReadPartId]) {
+				mostReadPartId = partId;
+			}
+		}
+		
+		// Debug
+		if (task.getTxNum() % 5000 == 0) {
+			System.out.println(String.format("========= Tx.%d ==========", task.getTxNum()));
+			System.out.println("Reads: " + Arrays.toString(readDistribution));
+			System.out.println("Most Read: " + mostReadPartId);
+		}
+		
+		// If that is the partition to avoid, try to find the second most one (if exists)
+		if (mostReadPartId != PART_TO_AVOID)
+			return mostReadPartId;
+		
+		int secondMostPartId = (mostReadPartId + 1) % PartitionMetaMgr.NUM_PARTITIONS;
+		for (int offset = 2; offset < PartitionMetaMgr.NUM_PARTITIONS; offset++) {
+			int partId = (mostReadPartId + offset) % PartitionMetaMgr.NUM_PARTITIONS;
+			if (readDistribution[partId] > readDistribution[secondMostPartId]) {
+				secondMostPartId = partId;
+			}
+		}
+		
+		// Debug
+		if (task.getTxNum() % 5000 == 0) {
+			System.out.println("Trying to avoid hot partition");
+			System.out.println("Second most Read: " + secondMostPartId);
+		}
+		
+		if (readDistribution[secondMostPartId] > 0)
+			return secondMostPartId;
+		
+//		return PART_TO_AVOID + (int) (task.getTxNum() % (PartitionMetaMgr.NUM_PARTITIONS - 1) + 1);
+		return mostReadPartId;
+	}
+}

--- a/src/main/java/org/elasql/schedule/tpart/hermes/FusionTable.java
+++ b/src/main/java/org/elasql/schedule/tpart/hermes/FusionTable.java
@@ -5,11 +5,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.elasql.server.Elasql;
 import org.elasql.sql.PrimaryKey;
 import org.elasql.storage.metadata.PartitionMetaMgr;
 import org.elasql.util.ElasqlProperties;
-import org.elasql.util.PeriodicalJob;
 import org.vanilladb.core.sql.Constant;
 
 public class FusionTable {
@@ -111,21 +109,21 @@ public class FusionTable {
 //		}).start();
 		
 		// Debug: Show the TPC-C records of partition 0 are distributed in each partition
-		new PeriodicalJob(5_000, 360_000, new Runnable() {
-			@Override
-			public void run() {
-				long time = System.currentTimeMillis() - Elasql.START_TIME_MS;
-				time /= 1000;
-				
-				StringBuffer sb = new StringBuffer();
-				sb.append(String.format("Time: %d seconds - Data: ", time));
-				for (int i = 0; i < countsPerParts.length; i++)
-					sb.append(String.format("%d, ", countsPerParts[i]));
-				sb.delete(sb.length() - 2, sb.length());
-				
-				System.out.println(sb.toString());
-			}
-		}).start();
+//		new PeriodicalJob(5_000, 360_000, new Runnable() {
+//			@Override
+//			public void run() {
+//				long time = System.currentTimeMillis() - Elasql.START_TIME_MS;
+//				time /= 1000;
+//				
+//				StringBuffer sb = new StringBuffer();
+//				sb.append(String.format("Time: %d seconds - Data: ", time));
+//				for (int i = 0; i < countsPerParts.length; i++)
+//					sb.append(String.format("%d, ", countsPerParts[i]));
+//				sb.delete(sb.length() - 2, sb.length());
+//				
+//				System.out.println(sb.toString());
+//			}
+//		}).start();
 
 		// Debug: show how many records are cached in each table
 //		new PeriodicalJob(5_000, 2400_000, new Runnable() {

--- a/src/main/java/org/elasql/schedule/tpart/hermes/FusionTable.java
+++ b/src/main/java/org/elasql/schedule/tpart/hermes/FusionTable.java
@@ -264,53 +264,12 @@ public class FusionTable {
 		return new HashSet<PrimaryKey>(overflowedKeys.keySet());
 	}
 	
-	private Integer getWarehouseId(PrimaryKey key) {
-		// For other tables, partitioned by wid
-		Constant widCon;
-		switch (key.getTableName()) {
-		case "warehouse":
-			widCon = key.getVal("w_id");
-			break;
-		case "district":
-			widCon = key.getVal("d_w_id");
-			break;
-		case "stock":
-			widCon = key.getVal("s_w_id");
-			break;
-		case "customer":
-			widCon = key.getVal("c_w_id");
-			break;
-		case "history":
-			widCon = key.getVal("h_c_w_id");
-			break;
-		case "orders":
-			widCon = key.getVal("o_w_id");
-			break;
-		case "new_order":
-			widCon = key.getVal("no_w_id");
-			break;
-		case "order_line":
-			widCon = key.getVal("ol_w_id");
-			break;
-		default:
-			return null;
-		}
-		
-		return (Integer) widCon.asJavaVal();
-	}
-	
-	private boolean isPartition0Record(PrimaryKey key) {
-		return getWarehouseId(key) <= 10;
-	}
-	
 	private void incrementCount(PrimaryKey key, int partId) {
-		if (isPartition0Record(key))
-			countsPerParts[partId]++;
+		countsPerParts[partId]++;
 	}
 	
 	private void decrementCount(PrimaryKey key, int partId) {
-		if (isPartition0Record(key))
-			countsPerParts[partId]--;
+		countsPerParts[partId]--;
 	}
 
 	private void insertNewRecord(PrimaryKey key, int partId) {

--- a/src/main/java/org/elasql/server/Elasql.java
+++ b/src/main/java/org/elasql/server/Elasql.java
@@ -292,7 +292,7 @@ public class Elasql extends VanillaDb {
 			graph = new FusionTGraph(table); 
 			inserter = new ControlBasedRouter(); 
 			sinker = new FusionSinker(table); 
-			isBatching = true; 
+			isBatching = false; 
 			break; 
 		default: 
 			throw new IllegalArgumentException("Not supported"); 
@@ -382,7 +382,7 @@ public class Elasql extends VanillaDb {
 			case HERMES_CONTROL:
 				graph = new FusionTGraph(new FusionTable()); 
 				inserter = new ControlBasedRouter();
-				isBatching = true;
+				isBatching = false;
 				break; 
 			default: 
 				throw new IllegalArgumentException("Not supported"); 

--- a/src/main/java/org/elasql/server/Elasql.java
+++ b/src/main/java/org/elasql/server/Elasql.java
@@ -269,7 +269,8 @@ public class Elasql extends VanillaDb {
 		case HERMES: 
 			table = new FusionTable(); 
 			graph = new FusionTGraph(table); 
-			inserter = new HermesNodeInserter(); 
+			inserter = new HermesNodeInserter();
+//			inserter = new HotAvoidanceRouter();
 			sinker = new FusionSinker(table); 
 			isBatching = true; 
 			break; 
@@ -351,45 +352,46 @@ public class Elasql extends VanillaDb {
 	}
 	
 	private static TPartPerformanceManager newTPartPerfMgr(TPartStoredProcedureFactory factory) {
-		TGraph graph; 
-		BatchNodeInserter inserter;
-		FusionTable table; 
-		boolean isBatching = true;
-		 
-		switch (SERVICE_TYPE) { 
-		case TPART: 
-			graph = new TGraph(); 
-			inserter = new CostAwareNodeInserter();
-			isBatching = true;
-			break; 
-		case HERMES: 
-			table = new FusionTable(); 
-			graph = new FusionTGraph(table); 
-			inserter = new HermesNodeInserter();
-			isBatching = true;
-			break; 
-		case G_STORE: 
-			graph = new TGraph(); 
-			inserter = new LocalFirstNodeInserter();
-			isBatching = false;
-			break; 
-		case LEAP: 
-			table = new FusionTable(); 
-			graph = new FusionTGraph(table); 
-			inserter = new LocalFirstNodeInserter();
-			isBatching = false;
-			break; 
-		case HERMES_CONTROL:
-			table = new FusionTable(); 
-			graph = new FusionTGraph(table); 
-			inserter = new ControlBasedRouter();
-			isBatching = true;
-			break; 
-		default: 
-			throw new IllegalArgumentException("Not supported"); 
-		} 
-		 
-		return new TPartPerformanceManager(factory, inserter, graph, isBatching); 
+		if (isStandAloneSequencer()) {
+			TGraph graph = null; 
+			BatchNodeInserter inserter;
+			boolean isBatching = true;
+			 
+			switch (SERVICE_TYPE) { 
+			case TPART: 
+				graph = new TGraph(); 
+				inserter = new CostAwareNodeInserter();
+				isBatching = true;
+				break; 
+			case HERMES:
+				graph = new FusionTGraph(new FusionTable()); 
+				inserter = new HermesNodeInserter();
+//				inserter = new HotAvoidanceRouter();
+				isBatching = true;
+				break; 
+			case G_STORE: 
+				graph = new TGraph(); 
+				inserter = new LocalFirstNodeInserter();
+				isBatching = false;
+				break; 
+			case LEAP: 
+				graph = new FusionTGraph(new FusionTable()); 
+				inserter = new LocalFirstNodeInserter();
+				isBatching = false;
+				break; 
+			case HERMES_CONTROL:
+				graph = new FusionTGraph(new FusionTable()); 
+				inserter = new ControlBasedRouter();
+				isBatching = true;
+				break; 
+			default: 
+				throw new IllegalArgumentException("Not supported"); 
+			} 
+			 
+			return TPartPerformanceManager.newForSequencer(factory, inserter, graph, isBatching); 
+		} else {
+			return TPartPerformanceManager.newForDbServer();
+		}
 	}
  
 	// ================ 

--- a/src/main/resources/org/elasql/elasql.properties
+++ b/src/main/resources/org/elasql/elasql.properties
@@ -159,4 +159,8 @@ org.elasql.perf.tpart.control.PidController.K_D=0.0
 org.elasql.perf.tpart.control.RoutingControlActuator.UPDATE_PERIOD=5000
 # TPC-C = 0.0004, YCSB = 0.019
 org.elasql.perf.tpart.control.RoutingControlActuator.INITIAL_ALPHA=1.0
+# CPU Max Capacities
+# 0.5 => Set the CPU max of server 0 as 50%, the max for the rest servers is 100%
+# 0.5,0.25 => Set the CPU max of server 0 and 1 as 50% and 25% respectively. 
+org.elasql.perf.tpart.control.RoutingControlActuator.CPU_MAX_CAPACITIES=1.0
 

--- a/src/main/resources/org/elasql/elasql.properties
+++ b/src/main/resources/org/elasql/elasql.properties
@@ -157,4 +157,6 @@ org.elasql.perf.tpart.control.PidController.K_I=0.0
 org.elasql.perf.tpart.control.PidController.K_D=0.0
 
 org.elasql.perf.tpart.control.RoutingControlActuator.UPDATE_PERIOD=5000
+# TPC-C = 0.0004, YCSB = 0.019
+org.elasql.perf.tpart.control.RoutingControlActuator.INITIAL_ALPHA=1.0
 


### PR DESCRIPTION
Bug Fixes

- Make collecting training data also works with HERMES_CONTROL
- Avoid creating duplicate router and fusion table in db servers

Enhancements

- Make `ReadCountEstimator` works for both TPC-C and YCSB with read count <= 24
- Add property `INITIAL_ALPHA` to control the initial value of alphaes
- Add property `CPU_MAX_CAPACITIES` to set the maximal capacity of CPU
- Improve debug logging
- Add `HotAvoidanceRouter` to test the ideal routing strategy on hotspot workloads
- Disable batching for HERMES_CONTROL

Add Features

- `Block Lock Release Count`
- `Block Lock Wait Count`
- `File Header Page Release Count`
- `File Header Page Wait Count`
- `Page GetVal Wait Count`
- `Page SetVal Wait Count`
- `Page GetVal Release Count`
- `Page SetVal Release Count`

