### PR TITLE
Version 0.3.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 0.3.1 (2021-01-07)
+
+### Security Issue
+
+- Bump vanillacomm from 0.2.5 to 0.2.6 due to the vulnerability of log4j
+
 ## Version 0.3.0 (2021-07-22)
 
 ### System Implementations

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.9</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>org.vanilladb</groupId>
 			<artifactId>comm</artifactId>
-			<version>0.2.5</version>
+			<version>0.2.6</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.elasql</groupId>
 	<artifactId>elasql</artifactId>
-	<version>0.3.0</version>
+	<version>0.3.1</version>
 	<packaging>jar</packaging>
 
 	<name>elasql</name>


### PR DESCRIPTION
### Security Issue

- Bump vanillacomm from 0.2.5 to 0.2.6 due to the vulnerability of log4j.
  - #43